### PR TITLE
Allow retroactive edits of existing CarePlan

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,12 +3,12 @@ import FhirClientProvider from "./FhirClientProvider";
 import './style/App.scss';
 import {LocalizationProvider} from "@mui/x-date-pickers";
 import {AdapterMoment} from '@mui/x-date-pickers/AdapterMoment';
-import {EnrollmentApp} from "./components/EnrollmentApp";
 import {MessagingApp} from "./components/MessagingApp";
 import {fetchEnvData, getEnv} from "./util/util";
 import {theme} from "./theme";
 import {ThemeProvider} from '@mui/material/styles';
 import SizeIndicator from "./components/SizeIndicator";
+import EnrollmentApp from "./components/EnrollmentApp";
 
 fetchEnvData();
 const REACT_APP_CLIENT_ID = getEnv("REACT_APP_CLIENT_ID");

--- a/src/FhirClientProvider.tsx
+++ b/src/FhirClientProvider.tsx
@@ -22,6 +22,7 @@ export default function FhirClientProvider(props: Props): JSX.Element {
     const [error, setError] = React.useState('');
     const [patient, setPatient] = React.useState(null);
     const [carePlan, setCarePlan] = React.useState(null);
+    const [loaded, setLoaded] = React.useState(false);
 
     async function getPatient(client: Client): Promise<Patient> {
         if (!client) return;
@@ -44,6 +45,7 @@ export default function FhirClientProvider(props: Props): JSX.Element {
         let params = new URLSearchParams({
             "subject": `Patient/${patientId}`,
             "category": IsaccCarePlanCategory.isaccMessagePlan.code,
+            "status": "active",
             "_sort": "-_lastUpdated"
         }).toString();
         return await client.request(`/CarePlan?${params}`).then((bundle: Bundle) => {
@@ -84,18 +86,23 @@ export default function FhirClientProvider(props: Props): JSX.Element {
                         setCarePlan(carePlanResult);
                         if (carePlanResult) {
                             console.log(`Loaded ${carePlanResult.reference}`);
-
                         }
+                        setLoaded(true);
                     }, (reason: any) => setError(reason)).catch(e => {
                         console.log("Error fetching CarePlan", e)
                         setError(e);
+                        setLoaded(true);
                     });
                 }).catch(e => {
                     console.log("Error fetching Patient", e)
                     setError(e);
+                    setLoaded(true);
                 });
 
-            }, (reason: any) => setError(reason)
+            }, (reason: any) => {
+                setError(reason);
+                setLoaded(true);
+            }
         );
     }, []);
 
@@ -114,7 +121,7 @@ export default function FhirClientProvider(props: Props): JSX.Element {
                     }
 
                     // if client is already available render the subtree
-                    if (context.client && context.patient) {
+                    if (loaded) {
                         return props.children;
                     }
 

--- a/src/components/EnrollmentApp.tsx
+++ b/src/components/EnrollmentApp.tsx
@@ -1,7 +1,223 @@
 import {AppPageScaffold} from "./AppPage";
 import ScheduleSetup from "./ScheduleSetup";
 import React from "react";
+import {FhirClientContext, FhirClientContextType} from "../FhirClientContext";
+import Client from "fhirclient/lib/Client";
+import {CommunicationRequest} from "../model/CommunicationRequest";
+import {makeCarePlan} from "../model/modelUtil";
+import {Button, CircularProgress} from "@mui/material";
+import CarePlan from "../model/CarePlan";
+import DialogContent from "@mui/material/DialogContent";
+import DialogContentText from "@mui/material/DialogContentText";
+import DialogActions from "@mui/material/DialogActions";
+import {IsaccMessageCategory} from "../model/CodeSystem";
+import {IBundle_Entry, ICommunicationRequest} from "@ahryman40k/ts-fhir-types/lib/R4";
+import {getDefaultMessageSchedule} from "../model/PlanDefinition";
+import {getUsername} from "../util/isacc_util";
+import Patient from "../model/Patient";
+import {Bundle} from "../model/Bundle";
 
-export const EnrollmentApp = () => <AppPageScaffold title={"Patient enrollment"}>
-    <ScheduleSetup/>
-</AppPageScaffold>
+type EnrollmenAppState = {
+    activeCarePlan: CarePlan;
+    editMode: boolean;
+    error: string;
+}
+
+export default class EnrollmentApp extends React.Component<{}, EnrollmenAppState> {
+    static contextType = FhirClientContext;
+
+    constructor(props: {}) {
+        super(props);
+        this.state = {
+            activeCarePlan: null,
+            editMode: null,
+            error: null
+        };
+    }
+
+    createNewCarePlan(): CarePlan {
+        //@ts-ignore
+        let patient: Patient = this.context.patient;
+        //@ts-ignore
+        let client: Client = this.context.client;
+
+        let planDefinition = getDefaultMessageSchedule();
+
+        let replacements: { [key: string]: number } = {};
+        let preferred_username = getUsername(client);
+        if (preferred_username) {
+            replacements['{userName}'] = preferred_username;
+        }
+
+        const messages: CommunicationRequest[] = planDefinition.createMessageList(patient, replacements);
+        const carePlan = makeCarePlan(planDefinition, patient, messages);
+
+        return carePlan;
+    }
+
+    discontinueExistingCarePlan() {
+        // @ts-ignore
+        let client: Client = this.context.client;
+        //@ts-ignore
+        let existingCarePlan: CarePlan = this.context.carePlan;
+        //@ts-ignore
+        let patient: Patient = this.context.patient;
+
+        let params = new URLSearchParams({
+            "recipient": `Patient/${patient.id}`,
+            "category": IsaccMessageCategory.isaccScheduledMessage.code,
+            "status": "active",
+            "based-on": existingCarePlan.reference,
+            "_sort": "occurrence",
+            "_count": "1000"
+        }).toString();
+
+        client.request(`CommunicationRequest?${params}`).then((bundle: Bundle) => {
+            if (bundle.type !== "searchset") {
+                this.setState({error: `Unexpected bundle type returned: ${bundle.type}`});
+                return null;
+            }
+            if (!bundle.entry) {
+                return null;
+            }
+            let crsToRevoke: CommunicationRequest[] = bundle.entry.map((e: IBundle_Entry) => {
+                if (e.resource.resourceType === 'CommunicationRequest') {
+                    return CommunicationRequest.from(e.resource as ICommunicationRequest);
+                } else {
+                    this.setState({error: `Unexpected resource type returned: ${e.resource.resourceType}`});
+                    return null;
+                }
+            })
+            crsToRevoke.forEach((cr) => {
+                cr.status = "revoked";
+                client.update(cr).then(
+                    //onfulfilled
+                    (value) => console.log(`CommunicationRequest/${cr.id} successfully revoked:`, value),
+                    //onrejected
+                    (rejectionReason) => console.log(`CommunicationRequest/${cr.id} revocation rejected:`, rejectionReason)
+                ).catch(
+                    (errorReason) => console.log(`CommunicationRequest/${cr.id} revocation caused error:`, errorReason)
+                );
+            });
+
+        }).then(() => {
+            existingCarePlan.status = "revoke";
+            client.update(existingCarePlan).then(
+                //onfulfilled
+                (value) => console.log(`CarePlan/${existingCarePlan.id} revocation successful:`, value),
+                //onrejected
+                (rejectionReason) => console.log(`CarePlan/${existingCarePlan.id} revocation rejected:`, rejectionReason)
+            ).catch(
+                (errorReason) => console.log(`CarePlan/${existingCarePlan.id} revocation caused error:`, errorReason)
+            );
+        });
+    }
+
+    componentWillMount() {
+        if (!this.state || !this.context) return;
+
+        //@ts-ignore
+        let existingCarePlan: CarePlan = this.context.carePlan;
+
+        //@ts-ignore
+        let context: FhirClientContextType = this.context;
+
+        if (this.state.activeCarePlan == null) {
+            if (existingCarePlan == null) {
+                let cp = this.createNewCarePlan();
+                context.carePlan = cp;
+                this.setState({activeCarePlan: cp});
+            }
+        }
+    }
+
+    private handleSetEditModeFalse() {
+        this.discontinueExistingCarePlan();
+
+        let cp = this.createNewCarePlan();
+
+        //@ts-ignore
+        let context: FhirClientContextType = this.context;
+        context.carePlan = cp;
+        this.setState({activeCarePlan: cp, editMode: false});
+    }
+
+    private handleSetEditModeTrue() {
+        //@ts-ignore
+        let context: FhirClientContextType = this.context;
+
+        let client: Client = context.client;
+        let patient: Patient = context.patient;
+        let existingCarePlan: CarePlan = context.carePlan;
+
+        //load associated communication requests
+        let params = new URLSearchParams({
+            "recipient": `Patient/${patient.id}`,
+            "based-on": `CarePlan/${existingCarePlan.id}`,
+            "category": IsaccMessageCategory.isaccScheduledMessage.code
+        }).toString();
+        client.request(`CommunicationRequest?${params}`).then((bundle: Bundle) => {
+            if (bundle.type === "searchset") {
+                if (!bundle.entry) return [];
+
+                let crs: CommunicationRequest[] = bundle.entry.map((e: IBundle_Entry) => {
+                    if (e.resource.resourceType !== "CommunicationRequest") {
+                        this.setState({error: "Unexpected resource type returned"});
+                        return null;
+                    } else {
+                        console.log("CommunicationRequest loaded:", e);
+                        return CommunicationRequest.from(e.resource);
+                    }
+                })
+                existingCarePlan.setCommunicationRequests(crs);
+                context.carePlan = existingCarePlan;
+                this.setState({activeCarePlan: existingCarePlan, editMode: true});
+            } else {
+                this.setState({error: "Unexpected bundle type returned"});
+                return null;
+            }
+        })
+    }
+
+    render(): React.ReactNode {
+        if (!this.state || !this.context) return <CircularProgress/>;
+
+        let view = <CircularProgress/>;
+        if (this.state.activeCarePlan != null) {
+            view = <ScheduleSetup/>;
+        } else if (this.state.editMode == null) {
+            view = this.getCarePlanAlreadyExistsView();
+        }
+
+        return <AppPageScaffold title={"Patient enrollment"}>
+            {view}
+        </AppPageScaffold>;
+    }
+
+    getCarePlanAlreadyExistsView(): JSX.Element {
+        let edit = () => {
+            this.handleSetEditModeTrue();
+        };
+        let createNew = () => this.handleSetEditModeFalse();
+
+        // @ts-ignore
+        let existingCarePlan: CarePlan = this.context.carePlan;
+        let creationDate = existingCarePlan?.created
+        let alertMessage = `The patient already has a CarePlan. Would you like to edit this CarePlan or revoke it and create a new one?`;
+        if (creationDate) {
+            alertMessage = `The patient already has a CarePlan (created ${new Date(creationDate)}). Would you like to edit this CarePlan or revoke it and create a new one?`;
+        }
+
+        return <DialogContent>
+            <DialogContentText>{alertMessage}</DialogContentText>
+            <DialogActions>
+                <Button
+                    onClick={edit} autoFocus>Edit</Button>
+                <Button
+                    onClick={createNew} autoFocus>Revoke and create new</Button>
+
+            </DialogActions>
+        </DialogContent>;
+
+    }
+}

--- a/src/components/EnrollmentApp.tsx
+++ b/src/components/EnrollmentApp.tsx
@@ -195,9 +195,7 @@ export default class EnrollmentApp extends React.Component<{}, EnrollmenAppState
     }
 
     getCarePlanAlreadyExistsView(): JSX.Element {
-        let edit = () => {
-            this.handleSetEditModeTrue();
-        };
+        let edit = () => this.handleSetEditModeTrue();
         let createNew = () => this.handleSetEditModeFalse();
 
         // @ts-ignore
@@ -215,7 +213,6 @@ export default class EnrollmentApp extends React.Component<{}, EnrollmenAppState
                     onClick={edit} autoFocus>Edit</Button>
                 <Button
                     onClick={createNew} autoFocus>Revoke and create new</Button>
-
             </DialogActions>
         </DialogContent>;
 

--- a/src/components/MessagingView.tsx
+++ b/src/components/MessagingView.tsx
@@ -184,7 +184,7 @@ export default class MessagingView extends React.Component<{}, {
     private saveMessage() {
         // @ts-ignore
         let context: FhirClientContextType = this.context;
-        let newMessage: CommunicationRequest = CommunicationRequest.createNewOutgoingMessage(this.state.activeMessage, context.patient, context.carePlan);
+        let newMessage: CommunicationRequest = CommunicationRequest.createNewManualOutgoingMessage(this.state.activeMessage, context.patient, context.carePlan);
         console.log("Attempting to save new CommunicationRequest:", newMessage);
         context.client.create(newMessage).then(
             (savedCommunicationRequest: IResource) => {

--- a/src/components/ScheduleSetup.tsx
+++ b/src/components/ScheduleSetup.tsx
@@ -283,7 +283,6 @@ const MessageScheduleList = (props: {
 
                 <Grid item>
                     <DateTimePicker
-
                         label={message.status === "completed" ? "Delivered Date & Time" : "Scheduled Date & Time"}
                         value={message.occurrenceDateTime}
                         inputFormat="ddd, MM/DD/YYYY hh:mm A" // example output display: Thu, 03/09/2023 09:34 AM
@@ -292,7 +291,8 @@ const MessageScheduleList = (props: {
                             message.setOccurrenceDate(newValue);
                             props.onMessagePlanChanged(props.messagePlan);
                         }}
-                        renderInput={(params: TextFieldProps) => <TextField {...params} />}/>
+                        renderInput={(params: TextFieldProps) => <TextField {...params} sx={{ width: "264px" }} />}
+                    />
                 </Grid>
                 <Grid item flexGrow={1}>
                     <TextField

--- a/src/components/ScheduleSetup.tsx
+++ b/src/components/ScheduleSetup.tsx
@@ -3,6 +3,7 @@ import {
     Button,
     CircularProgress,
     Grid,
+    IconButton,
     List,
     ListItem,
     Snackbar,
@@ -14,7 +15,6 @@ import {
 import ClearIcon from '@mui/icons-material/Clear';
 import {DateTimePicker} from "@mui/x-date-pickers";
 import {FhirClientContext} from "../FhirClientContext";
-import {makeCarePlan, makeCommunicationRequests} from "../model/modelUtil";
 import {IResource} from "@ahryman40k/ts-fhir-types/lib/R4";
 import {CommunicationRequest} from "../model/CommunicationRequest";
 import Alert from "@mui/material/Alert";
@@ -27,16 +27,16 @@ import DialogContentText from "@mui/material/DialogContentText";
 import DialogActions from "@mui/material/DialogActions";
 import Dialog from "@mui/material/Dialog";
 import Client from "fhirclient/lib/Client";
-import {getUsername} from "../util/isacc_util";
+import PatientNotes from "./PatientNotes";
+import CarePlan from "../model/CarePlan";
 
 
 interface ScheduleSetupProps {
 }
 
 type ScheduleSetupState = {
-    messages: MessageDraft[];
-    patientNote: string;
-    showAlert: boolean;
+    carePlan: CarePlan;
+    showCloseSchedulePlannerAlert: boolean;
     alertSeverity: "error" | "warning" | "info" | "success";
     alertText: string;
     savingInProgress: boolean;
@@ -64,9 +64,8 @@ export default class ScheduleSetup extends React.Component<ScheduleSetupProps, S
     constructor(props: ScheduleSetupProps) {
         super(props);
         this.state = {
-            messages: null,
-            patientNote: '',
-            showAlert: false,
+            carePlan: null,
+            showCloseSchedulePlannerAlert: false,
             alertText: null,
             alertSeverity: null,
             savingInProgress: false
@@ -76,58 +75,74 @@ export default class ScheduleSetup extends React.Component<ScheduleSetupProps, S
 
     componentDidMount() {
         //@ts-ignore
-        let patient: Patient = this.context.patient;
-        //@ts-ignore
-        let client: Client = this.context.client;
-
-        let replacements: { [key: string]: number } = {};
-        let preferred_username = getUsername(client);
-        if (preferred_username) {
-            replacements['{userName}'] = preferred_username;
-        }
-
-        const messages: MessageDraft[] = this.planDefinition.createMessageList(patient, replacements);
-        this.setState({messages: messages});
+        let carePlan: CarePlan = this.context.carePlan;
+        this.setState({carePlan: carePlan});
     }
 
     render(): React.ReactNode {
-        if (!this.state || !this.state.messages) return <CircularProgress/>;
+        if (!this.state || !this.state.carePlan || !this.context) return <CircularProgress/>;
+
+        //@ts-ignore
+        let patient: Patient = this.context.patient;
+
+        let editing = this.state.carePlan.id != null;
+
 
         return <>
+            {editing ?
+                <Alert severity={"info"}>
+                    {`You are editing an existing CarePlan (CarePlan/${this.state.carePlan.id}, created ${new Date(this.state.carePlan.created)})`}
+                </Alert>
+                : null}
             <Grid container spacing={2}>
                 <Grid item xs={6}><Summary editable={true}/></Grid>
                 <Grid item xs={6}>
-                    <Typography variant={'h6'}>{"Patient note"}</Typography>
-                    <TextField
-                        sx={{maxHeight: 400, overflow: 'auto', ...styles.patientNotesField}}
-                        fullWidth
-                        multiline
-                        value={this.state.patientNote ?? ""}
-                        placeholder={"Patient note"}
-                        onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                            this.setState({patientNote: event.target.value});
-                        }}/>
+                    {editing ?
+                        <PatientNotes/> :
+                        <>
+                            <Typography variant={'h6'}>{"Patient note"}</Typography>
+                            <TextField
+                                sx={{maxHeight: 400, overflow: 'auto', ...styles.patientNotesField}}
+                                fullWidth
+                                multiline
+                                value={this.state.carePlan.description ?? ""}
+                                placeholder={"Patient note"}
+                                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                                    const cp = this.state.carePlan;
+                                    cp.description = event.target.value;
+                                    this.setState({carePlan: cp});
+                                }}/>
+                        </>
+                    }
                 </Grid>
                 <Grid item xs={12}>
                     <MessageScheduleList
-                        messages={this.state.messages}
-                        onMessagesChanged={(messages: MessageDraft[]) => this.setState({messages: messages})}
+                        messagePlan={this.state.carePlan}
+                        onMessagePlanChanged={(carePlan: CarePlan) => {
+                            this.setState({carePlan: carePlan});
+                        }}
                         saveSchedule={() => this.saveSchedule()}
+                        patient={patient}
                     />
                 </Grid>
             </Grid>
 
-            {this.getAlert()}
+            {this.getCloseSchedulePlannerAlert()}
         </>
     }
 
     private showSnackbar(alertSeverity: "error" | "warning" | "info" | "success", alertText: string) {
-        this.setState({showAlert: true, alertSeverity: alertSeverity, alertText: alertText, savingInProgress: false});
+        this.setState({
+            showCloseSchedulePlannerAlert: true,
+            alertSeverity: alertSeverity,
+            alertText: alertText,
+            savingInProgress: false
+        });
     }
 
-    private getAlert() {
+    private getCloseSchedulePlannerAlert() {
         let clearSessionLink = getEnv("REACT_APP_DASHBOARD_URL") + "/clear_session";
-        let onClose = () => this.setState({showAlert: false});
+        let onClose = () => this.setState({showCloseSchedulePlannerAlert: false});
 
         if (this.state.savingInProgress) {
             return <Dialog open={this.state.savingInProgress}>
@@ -139,7 +154,7 @@ export default class ScheduleSetup extends React.Component<ScheduleSetupProps, S
         }
 
         if (this.state.alertSeverity === 'success') {
-            return <Dialog open={this.state.showAlert}
+            return <Dialog open={this.state.showCloseSchedulePlannerAlert}
                            onClose={onClose}>
                 <DialogContent>
                     <DialogContentText>{this.state.alertText}</DialogContentText>
@@ -152,7 +167,7 @@ export default class ScheduleSetup extends React.Component<ScheduleSetupProps, S
                 </DialogContent>
             </Dialog>;
         }
-        return <Snackbar open={this.state.showAlert}
+        return <Snackbar open={this.state.showCloseSchedulePlannerAlert}
                          autoHideDuration={6000}
                          onClose={onClose}>
             <Alert
@@ -164,6 +179,7 @@ export default class ScheduleSetup extends React.Component<ScheduleSetupProps, S
             </Alert>
         </Snackbar>;
     }
+
 
     private saveSchedule() {
         // @ts-ignore
@@ -182,27 +198,41 @@ export default class ScheduleSetup extends React.Component<ScheduleSetupProps, S
         }
         this.setState({savingInProgress: true});
 
-        if (this.state.messages.find((m: MessageDraft) => m.text.length === 0)) {
+        if (this.state.carePlan.communicationRequests.find((m: CommunicationRequest) => m.getText().length === 0)) {
             this.showSnackbar("error", "Messages cannot be empty");
             return;
         }
 
         client.update(patient).then((value: any) => console.log(`Patient ${patient.id} updated`));
 
-        let communicationRequests = makeCommunicationRequests(patient, this.planDefinition, this.state.messages);
-        let promises = communicationRequests.map(
-            (c: CommunicationRequest) => client.create(c).then(
-                (value: any) => CommunicationRequest.from(value)
-            )
+        let promises = this.state.carePlan.communicationRequests.map(
+            (c: CommunicationRequest) => {
+                let p;
+                if (c.id) {
+                    p = client.update(c);
+                } else {
+                    p = client.create(c);
+                }
+                return p.then(
+                    (value: any) => CommunicationRequest.from(value)
+                );
+            }
         );
 
         Promise.all(promises).then((communicationRequests: CommunicationRequest[]) => {
             communicationRequests.forEach((v: CommunicationRequest) => {
                 console.log("resource saved:", v);
             });
-            // create CarePlan with the newly created CommunicationRequests
-            let carePlan = makeCarePlan(this.planDefinition, patient, communicationRequests, this.state.patientNote);
-            client.create(carePlan).then((savedCarePlan: IResource) => {
+            // update CarePlan with the newly created CommunicationRequests
+            this.state.carePlan.setCommunicationRequests(communicationRequests);
+            // create resource on server
+            let p;
+            if (this.state.carePlan.id) {
+                p = client.update(this.state.carePlan);
+            } else {
+                p = client.create(this.state.carePlan);
+            }
+            p.then((savedCarePlan: IResource) => {
                 this.onSaved(savedCarePlan);
                 let updatePromises = communicationRequests.map((c: CommunicationRequest) => {
                     c.basedOn = [{reference: `CarePlan/${savedCarePlan.id}`}];
@@ -231,16 +261,22 @@ export default class ScheduleSetup extends React.Component<ScheduleSetupProps, S
 
 
 const MessageScheduleList = (props: {
-    messages: MessageDraft[],
-    onMessagesChanged: (messages: MessageDraft[]) => void,
+    messagePlan: CarePlan,
+    patient: Patient,
+    onMessagePlanChanged: (carePlan: CarePlan) => void,
     saveSchedule: () => void,
 }) => {
 
-    const buildMessageItem = (message: MessageDraft, index: number) => {
-        return <ListItem key={index} sx={{width: '100%'}} secondaryAction={
-            <ClearIcon onClick={() => {
+    const buildMessageItem = (message: CommunicationRequest, index: number) => {
+        return <ListItem key={index} sx={{
+            width: '100%'
+        }} secondaryAction={
+            message.status === "completed" ? <></> :
+            <IconButton hidden={message.status === "completed"} onClick={() => {
                 removeMessage(index);
-            }}/>
+            }}>
+                <ClearIcon/>
+            </IconButton>
         }>
             <Grid container direction={"row"} flexDirection={"row"} spacing={2}
                   sx={{paddingTop: 2}}>
@@ -248,30 +284,28 @@ const MessageScheduleList = (props: {
                 <Grid item>
                     <DateTimePicker
 
-                        label="Date & Time"
-                        value={message.scheduledDateTime}
+                        label={message.status === "completed" ? "Delivered Date & Time" : "Scheduled Date & Time"}
+                        value={message.occurrenceDateTime}
+                        disabled={message.status === "completed"}
                         onChange={(newValue: Date | null) => {
-                            // message.scheduledDateTime = newValue;
-                            let messages = props.messages;
-                            messages[index].scheduledDateTime = newValue;
-                            props.onMessagesChanged(messages);
-                            // this.setState({messages: this.state.messages});
+                            message.setOccurrenceDate(newValue);
+                            props.onMessagePlanChanged(props.messagePlan);
                         }}
                         renderInput={(params: TextFieldProps) => <TextField {...params} />}/>
                 </Grid>
                 <Grid item flexGrow={1}>
                     <TextField
-                        error={message.text.length === 0}
-                        helperText={message.text.length === 0 ? "Enter a message" : ""}
-                        label={"Message"}
+                        error={message.getText().length === 0}
+                        helperText={message.getText().length === 0 ? "Enter a message" : ""}
+                        label={message.status === "completed" ? "Delivered Message" : "Scheduled Message"}
                         fullWidth
                         multiline
-                        value={message.text ?? ""}
+                        value={message.getText() ?? ""}
                         placeholder={"Enter message"}
+                        disabled={message.status === "completed"}
                         onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                            props.messages[index].text = event.target.value;
-                            props.onMessagesChanged(props.messages);
-                            // this.setState({messages: this.state.messages});
+                            message.setText(event.target.value);
+                            props.onMessagePlanChanged(props.messagePlan);
                         }}/>
                 </Grid>
             </Grid>
@@ -279,9 +313,9 @@ const MessageScheduleList = (props: {
     }
 
     const removeMessage = (index: number) => {
-        let messages = props.messages;
-        messages.splice(index, 1);
-        props.onMessagesChanged(messages);
+        let messagePlan = props.messagePlan;
+        messagePlan.removeActiveCommunicationRequest(index);
+        props.onMessagePlanChanged(messagePlan);
     }
 
     return <><Typography variant={'h6'}>{"Message schedule"}</Typography>
@@ -290,17 +324,16 @@ const MessageScheduleList = (props: {
         </Alert>
 
         <List>{
-            props.messages.map((message: MessageDraft, index: number) => {
-                    return buildMessageItem(message, index);
-                }
+            props.messagePlan.getActiveCommunicationRequests().map(
+                (message: CommunicationRequest, index: number) => buildMessageItem(message, index)
             )
         }</List>
 
         <Stack direction={'row'} justifyContent={"space-between"}>
             <Button variant="outlined" onClick={() => {
-                props.messages.push({text: "", scheduledDateTime: new Date()});
-                props.onMessagesChanged(props.messages);
-                // this.setState({messages: this.state.messages});
+                let newMessage = CommunicationRequest.createNewScheduledMessage("", props.patient, props.messagePlan, new Date());
+                props.messagePlan.addCommunicationRequest(newMessage);
+                props.onMessagePlanChanged(props.messagePlan);
             }}>
                 Add message
             </Button>

--- a/src/model/CarePlan.ts
+++ b/src/model/CarePlan.ts
@@ -125,7 +125,7 @@ export default class CarePlan implements ICarePlan {
             this.updateActivityAttr();
         } else {
             requests.splice(index, 1);
-            this.updateActivityAttr();
+            this.setCommunicationRequests(requests);
         }
         // update activity array
     }

--- a/src/model/CarePlan.ts
+++ b/src/model/CarePlan.ts
@@ -127,7 +127,6 @@ export default class CarePlan implements ICarePlan {
             requests.splice(index, 1);
             this.setCommunicationRequests(requests);
         }
-        // update activity array
     }
 }
 

--- a/src/model/Patient.ts
+++ b/src/model/Patient.ts
@@ -7,7 +7,6 @@ import {
   IExtension,
   IHumanName,
   IIdentifier,
-  IMeta,
   INarrative,
   IPatient,
   IPatient_Communication,

--- a/src/model/modelUtil.ts
+++ b/src/model/modelUtil.ts
@@ -1,7 +1,5 @@
 import PlanDefinition from "./PlanDefinition";
-import CarePlan, {CarePlanActivity} from "./CarePlan";
-
-import {Medium} from "./CodeSystem";
+import CarePlan from "./CarePlan";
 import {CommunicationRequest} from "./CommunicationRequest";
 
 import Patient from "./Patient";
@@ -13,18 +11,10 @@ export function makeCommunicationRequests(patient: Patient, planDefinition: Plan
         let patientName = patient.name[0].given[0];
         let str = message.text.replace("{name}", patientName);
 
-        let c = new CommunicationRequest();
-        c.payload = [{contentString: str}];
-        c.occurrenceDateTime = message.scheduledDateTime.toISOString();
-        c.recipient = [{reference: patient.reference}]; // TODO: Reference to RelatedPerson
-        c.medium = [Medium.sms];
-        return c;
+        return CommunicationRequest.createNewScheduledMessage(str, patient, null, message.scheduledDateTime);
     });
 }
 
-export function makeCarePlan(planDefinition: PlanDefinition, patient: Patient, communicationRequests: CommunicationRequest[], patientNote: string): CarePlan {
-    let activities = communicationRequests.map((req) => CarePlanActivity.withReference(req.reference));
-    let carePlan = CarePlan.createIsaccCarePlan(patient, planDefinition, activities);
-    carePlan.description = patientNote;
-    return carePlan;
+export function makeCarePlan(planDefinition: PlanDefinition, patient: Patient, communicationRequests: CommunicationRequest[]): CarePlan {
+    return CarePlan.createIsaccCarePlan(patient, planDefinition, communicationRequests);
 }

--- a/src/test/CommunicationRequest.test.ts
+++ b/src/test/CommunicationRequest.test.ts
@@ -1,0 +1,87 @@
+import {CommunicationRequest} from "../model/CommunicationRequest";
+import Patient from "../model/Patient";
+import CarePlan from "../model/CarePlan";
+
+describe('CommunicationRequest tests', () => {
+    test('Generate scheduled message from PlanDefinition', () => {
+        let p = new Patient();
+        p.resourceType = "Patient";
+        p.id = "patientID";
+
+        let c: CommunicationRequest = CommunicationRequest.createNewScheduledMessage("hi", p, null, new Date("2023-03-09T20:58:14.219Z"));
+
+        expect(JSON.stringify(c)).toBe(JSON.stringify({
+            "resourceType": "CommunicationRequest",
+            "occurrenceDateTime": "2023-03-09T20:58:14.219Z",
+            "payload": [{"contentString": "hi"}],
+            "recipient": [{"reference": "Patient/patientID"}],
+            "status": "active",
+            "medium": [{"code": "SMSWRIT", "system": "http://terminology.hl7.org/ValueSet/v3-ParticipationMode"}],
+            "category": [{
+                "coding": [{
+                    "code": "isacc-scheduled-message",
+                    "system": "https://isacc.app/CodeSystem/communication-request-type"
+                }]
+            }]
+        }));
+    });
+
+    test('Add a new scheduled message (enrollment view)', () => {
+        let d = new Date();
+
+        let p = new Patient();
+        p.resourceType = "Patient";
+        p.id = "patientID";
+
+        let cp = new CarePlan();
+        cp.resourceType = 'CarePlan';
+        cp.id = "careplanID";
+
+        let c = CommunicationRequest.createNewScheduledMessage("hi", p, cp, d);
+
+        expect(JSON.stringify(c)).toBe(JSON.stringify({
+            "resourceType": "CommunicationRequest",
+            "occurrenceDateTime": d.toISOString(),
+            "payload": [{"contentString": "hi"}],
+            "recipient": [{"reference": "Patient/patientID"}],
+            "status": "active",
+            "medium": [{"code": "SMSWRIT", "system": "http://terminology.hl7.org/ValueSet/v3-ParticipationMode"}],
+            "category": [{
+                "coding": [{
+                    "code": "isacc-scheduled-message",
+                    "system": "https://isacc.app/CodeSystem/communication-request-type"
+                }]
+            }],
+            "basedOn": [{"reference": "CarePlan/careplanID"}]
+        }));
+    });
+    test('Create a new outgoing manual message (message view)', () => {
+
+        let p = new Patient();
+        p.resourceType = "Patient";
+        p.id = "patientID";
+
+        let cp = new CarePlan();
+        cp.resourceType = 'CarePlan';
+        cp.id = "careplanID";
+
+        let d = new Date();
+        let c = CommunicationRequest.createNewManualOutgoingMessage("hi", p, cp);
+
+        expect(JSON.stringify(c)).toBe(JSON.stringify({
+            "resourceType": "CommunicationRequest",
+            "occurrenceDateTime": d.toISOString(),
+            "payload": [{"contentString": "hi"}],
+            "recipient": [{"reference": "Patient/patientID"}],
+            "status": "active",
+            "medium": [{"code": "SMSWRIT", "system": "http://terminology.hl7.org/ValueSet/v3-ParticipationMode"}],
+            "category": [{
+                "coding": [{
+                    "code": "isacc-manually-sent-message",
+                    "system": "https://isacc.app/CodeSystem/communication-type"
+                }]
+            }],
+            "basedOn": [{"reference": "CarePlan/careplanID"}]
+        }));
+    });
+});


### PR DESCRIPTION
- Allow retroactive edits of existing CarePlan https://www.pivotaltracker.com/story/show/184551787
- Fix incorrect birthday message date/time https://www.pivotaltracker.com/story/show/182907996


### Testing instructions for CarePlan editing
1. Open Enrollment client for a patient that doesn't have a CarePlan yet. You should be taken to the new Enrollment client like normal.
- test patient note still works
- test that adding and removing message list entries still works
- the CarePlan and CommunicationRequest resources that are created (when hitting done) match what you entered. No extraneous resources are created (no “revoked” CommunicationRequests are generated)
- cannot save the plan with empty messages
2. Open Enrollment client for a patient that does have a CarePlan already. When prompted, click “revoke and create new”.
- the old CarePlan is marked “revoked”
- all (not yet executed) CommunicationRequest resources from old CarePlan are marked “revoked”
- CommunicationRequests that were already executed do not change
- Go to 1.
3. Open Enrollment client for a patient that does have a CarePlan already. When prompted, click “edit”.
- patient note shows what the existing CarePlan had. If you change it and save, the existing CarePlan reflects this change (description attribute)
- The message list from the previously created CarePlan is shown, with correct dates/times and content.
- If removing any messages, once you save:
  - the corresponding CommunicationRequest resources are marked “revoked”
  - the corresponding entry in CarePlan.activity has been removed
- Messages that have already been sent (CommunicationRequest resources with status “completed”) are marked as such visually, and cannot be removed
- If changing any message date or text, the corresponding CommunicationRequest resources reflect the changes