### PR TITLE
messages app - update layout to allow the messages within viewport

### DIFF
--- a/src/components/AppBanner.tsx
+++ b/src/components/AppBanner.tsx
@@ -1,29 +1,40 @@
-import React from "react";
-import {AppBar, Box, Button, IconButton, Toolbar, Typography} from "@mui/material";
+import React, {useContext} from "react";
+import {AppBar, Box, Button, IconButton, Stack, Toolbar, Typography} from "@mui/material";
 import {getPatientListURL} from "../util/isacc_util";
 import {ArrowBackIos} from "@mui/icons-material";
+import { FhirClientContext } from "../FhirClientContext";
 
 export default function AppBanner() {
-    return  <Box sx={{ flexGrow: 1 }}>
-        <AppBar position="static">
-            <Toolbar>
-                <IconButton
-                    size="large"
-                    edge="start"
-                    color="inherit"
-                    sx={{ mr: 2 }}
-                >
-                    <Button
-                        color='inherit'
-                        variant={'outlined'}
-                        href={getPatientListURL()}><ArrowBackIos/>
-                        Back to patient list
-                    </Button>
-                </IconButton>
-                <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
-                    ISACC
+    const { patient } = useContext(FhirClientContext);
+    return (
+      <Box sx={{ flexGrow: 1 }}>
+        <AppBar position="fixed">
+          <Toolbar>
+            <Stack sx={{ flexGrow: 1 }} direction="row" justifyContent="flex-start" spacing={2}>
+              <Typography variant="h4" component="h1">
+                ISACC
+              </Typography>
+              <Box>
+                <Typography variant="body2">
+                  {patient.fullNameDisplay}
                 </Typography>
-            </Toolbar>
+                <Typography variant="body2">
+                  {patient.birthDate}
+                </Typography>
+              </Box>
+            </Stack>
+            <IconButton size="large" edge="start" color="inherit">
+              <Button
+                color="inherit"
+                variant={"outlined"}
+                href={getPatientListURL()}
+              >
+                <ArrowBackIos />
+                Patient list
+              </Button>
+            </IconButton>
+          </Toolbar>
         </AppBar>
-    </Box>;
+      </Box>
+    );
 }

--- a/src/components/AppPage.tsx
+++ b/src/components/AppPage.tsx
@@ -5,7 +5,7 @@ import VersionString from "./VersionString";
 import AppBanner from "./AppBanner";
 import Box from "@mui/material/Box";
 
-const styles = {content: { "padding": "16px" }};
+const styles = {content: { "padding": "64px 16px 16px" }};
 
 type AppPageScaffoldProps = {
     title?: string | JSX.Element;
@@ -35,16 +35,13 @@ export const PageTitle: FunctionComponent<React.PropsWithChildren & PageTitlePro
 }
 
 export const AppPageScaffold: FunctionComponent<React.PropsWithChildren & AppPageScaffoldProps> = (props: React.PropsWithChildren<AppPageScaffoldProps>) => {
-
     function _content() {
         if (props.title) {
             // return title and divider with padding, followed by page content
             return <PageTitle title={props.title}>{props.children}</PageTitle>;
         }
         // return just the page content
-        return <Box sx={ styles.content }>
-            {props.children}
-        </Box>;
+        return <Box sx={styles.content}>{props.children}</Box>;
     }
 
     return (

--- a/src/components/MessagingApp.tsx
+++ b/src/components/MessagingApp.tsx
@@ -27,8 +27,8 @@ export const MessagingApp = () => {
         container
         direction={"row"}
         justifyContent={"center"}
-        rowSpacing={{ sx: 0, sm: 1 }}
-        columnSpacing={{ sx: 0, sm: 1 }}
+        rowSpacing={1}
+        columnSpacing={1}
       >
         <GridItem xs={12} sm={12} md={3} lg={3} xl={3}>
           <Stack direction={"column"} spacing={1} sx={{ width: "100%" }}>

--- a/src/components/MessagingApp.tsx
+++ b/src/components/MessagingApp.tsx
@@ -1,59 +1,77 @@
-import {AppPageScaffold} from "./AppPage";
-import {Card, CardContent, Grid, GridProps} from "@mui/material";
+import { AppPageScaffold } from "./AppPage";
+import { Grid, GridProps, Paper, Stack } from "@mui/material";
+import { styled } from "@mui/material/styles";
 import Summary from "./Summary";
 import PatientPROs from "./PatientPROs";
 import PatientNotes from "./PatientNotes";
 import MessageView from "./MessagingView";
-import React, {PropsWithChildren, useContext} from "react";
-import {FhirClientContext} from "../FhirClientContext";
+import React, { PropsWithChildren, useContext } from "react";
+import { FhirClientContext } from "../FhirClientContext";
 import Alert from "@mui/material/Alert";
 import DiagnosisAndCareTeam from "./DiagnosisAndCareTeam";
 
 export const MessagingApp = () => {
-    const context = useContext(FhirClientContext);
-    let content;
-    if (!context.carePlan) {
-        content = <Alert
-            severity="error">{"Patient has no ISACC CarePlan. Ensure the patient is enrolled and has a message schedule CarePlan."}</Alert>;
-    } else {
-        content = <Grid container direction={"row"} justifyContent={"center"}>
-            <GridItemWithCard xs={12} sm={8} md={3} lg={3} xl={3}>
-                <Summary/>
-            </GridItemWithCard>
-            <GridItemWithCard item xs={12} sm={4} md={2} lg={2} xl={1}>
-                <PatientPROs/>
-            </GridItemWithCard>
-            <GridItemWithoutCardContent xs={12} sm={8} md={4} lg={4} xl={5}>
-                <PatientNotes/>
-            </GridItemWithoutCardContent>
-            <GridItemWithCard xs={12} sm={4} md={3} lg={3} xl={3}>
-                <DiagnosisAndCareTeam/>
-            </GridItemWithCard>
-            {/*<GridItemWithCard sm={4} md={3} lg={3} xl={3}>{"Themes and stuff"} </GridItemWithCard>*/}
-            {/*left column*/}
-            <GridItemWithCard xs={12} md={6} lg={6} xl={6}>
-                <MessageView/>
-            </GridItemWithCard>
-            {/*<GridItemWithCard xs={4} md={3} lg={3} xl={3}>{"Continuation of themes and stuff"}</GridItemWithCard>*/}
-        </Grid>
-    }
-    return <AppPageScaffold title={"Messages"}>
-        {content}
-    </AppPageScaffold>;
-}
+  const context = useContext(FhirClientContext);
+  let content;
+  if (!context.carePlan) {
+    content = (
+      <Alert severity="error">
+        {
+          "Patient has no ISACC CarePlan. Ensure the patient is enrolled and has a message schedule CarePlan."
+        }
+      </Alert>
+    );
+  } else {
+    content = (
+      <Grid
+        container
+        direction={"row"}
+        justifyContent={"center"}
+        rowSpacing={{ sx: 0, sm: 1 }}
+        columnSpacing={{ sx: 0, sm: 1 }}
+      >
+        <GridItem xs={12} sm={12} md={3} lg={3} xl={3}>
+          <Stack direction={"column"} spacing={1} sx={{ width: "100%" }}>
+            <Item>
+              <Summary editable={false} />
+            </Item>
+            <Item>
+              <PatientNotes />
+            </Item>
+          </Stack>
+        </GridItem>
+        <GridItem xs={12} sm={12} md={6} lg={6} xl={6}>
+          <Item>
+            <MessageView />
+          </Item>
+        </GridItem>
+        <GridItem xs={12} sm={12} md={3} lg={3} xl={3}>
+          <Stack direction={"column"} spacing={1} sx={{ width: "100%" }}>
+            <Item>
+              <DiagnosisAndCareTeam />
+            </Item>
+            <Item>
+              <PatientPROs />
+            </Item>
+          </Stack>
+        </GridItem>
+      </Grid>
+    );
+  }
+  return <AppPageScaffold title={"Messages"}>{content}</AppPageScaffold>;
+};
 
-const GridItemWithoutCardContent = ({children, ...rest}: PropsWithChildren & GridProps) =>
-    <Grid item {...rest} flexGrow={1} display={"flex"}>
-        <Card variant={"outlined"} sx={{'flex-grow':"1"}}>
-            {children}
-        </Card>
-    </Grid>
+const Item = styled(Paper)(({ theme }) => ({
+  backgroundColor: "#fff",
+  ...theme.typography.body1,
+  padding: theme.spacing(2),
+  color: theme.palette.text.secondary,
+  flexGrow: 1,
+  border: "1px solid #ececec",
+}));
 
-const GridItemWithCard = ({children, ...rest}: PropsWithChildren & GridProps) =>
-    <Grid item {...rest} flexGrow={1} display={"flex"}>
-        <Card variant={"outlined"} sx={{
-            'flex-grow':"1"
-        }}>
-            <CardContent>{children}</CardContent>
-        </Card>
-    </Grid>
+const GridItem = ({ children, ...rest }: PropsWithChildren & GridProps) => (
+  <Grid item {...rest} flexGrow={1} display={"flex"}>
+    {children}
+  </Grid>
+);

--- a/src/components/MessagingView.tsx
+++ b/src/components/MessagingView.tsx
@@ -156,9 +156,9 @@ export default class MessagingView extends React.Component<{}, {
         }
 
 
-        return <Grid container direction={"column"}>
+        return <Grid container direction={"column"} sx={{backgroundColor: "#FFF"}}>
             <Stack direction={'row'} justifyContent={'space-between'}>
-                <Typography variant={'h6'} sx={{paddingTop: 2}}>{"Messages"}</Typography>
+                <Typography variant={'h6'}>{"Messages"}</Typography>
                 {this.state.messagesLoading ? <CircularProgress/> :
                     <IconButton color="primary" onClick={() => this.loadCommunications()}><Refresh/></IconButton>}
             </Stack>
@@ -167,6 +167,7 @@ export default class MessagingView extends React.Component<{}, {
 
             <TextField
                 multiline
+                InputProps={{sx: {marginTop: 0.25}}}
                 value={this.state.activeMessage ?? ""}
                 placeholder={"Enter message"}
                 onChange={(event: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/PatientNotes.tsx
+++ b/src/components/PatientNotes.tsx
@@ -38,35 +38,46 @@ export default class PatientNotes extends React.Component<PatientNotesProps, Pat
 
         if (!carePlan) return null;
 
-        return <>
-            <CardContent>
-                <Typography variant={"h6"}>Patient notes</Typography>
-                {this.state.editable ?
-                    <TextField
-                        InputProps={{sx: {typography: 'body2'}}}
-                        multiline
-                        fullWidth
-                        value={this.state.updatedPatientNote ?? ""}
-                        placeholder={"Enter patient note"}
-                        onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                            this.setState({updatedPatientNote: event.target.value});
-                        }}
-                    /> :
-                    <Typography variant={"body2"}>{carePlan.description}</Typography>
-                }
-                {this._updateError()}
+        return (
+          <>
+            <CardContent sx={{ padding: 0 }}>
+              <Typography variant={"h6"}>Patient notes</Typography>
+              {this.state.editable ? (
+                <TextField
+                  InputProps={{ sx: { typography: "body2" } }}
+                  multiline
+                  fullWidth
+                  value={this.state.updatedPatientNote ?? ""}
+                  placeholder={"Enter patient note"}
+                  onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                    this.setState({ updatedPatientNote: event.target.value });
+                  }}
+                />
+              ) : (
+                <Typography variant={"body2"}>
+                  {carePlan.description}
+                </Typography>
+              )}
+              {this._updateError()}
             </CardContent>
             <CardActions>
-                <Button onClick={() => {
-                    if (this.state.editable) {
-                        this.updateNote(this.state.updatedPatientNote)
-                    } else {
-                        this.setState({updatedPatientNote: carePlan.description, editable: true});
-                    }
-                }}>{this.state.editable ? "Done" : "Update"}</Button>
-
+              <Button
+                onClick={() => {
+                  if (this.state.editable) {
+                    this.updateNote(this.state.updatedPatientNote);
+                  } else {
+                    this.setState({
+                      updatedPatientNote: carePlan.description,
+                      editable: true,
+                    });
+                  }
+                }}
+              >
+                {this.state.editable ? "Done" : "Update"}
+              </Button>
             </CardActions>
-        </>;
+          </>
+        );
     }
 
     private _updateError() {

--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -110,7 +110,6 @@ export default class Summary extends React.Component<SummaryProps, SummaryState>
             let currentSelection = this.state.practitioners.filter(
                 (p: IPractitioner) => {
                     return patient.generalPractitioner?.find((gpRef: IReference) => {
-                        console.log("ref id ", gpRef.reference)
                         return gpRef.type === "Practitioner" && gpRef.reference.includes(p.id);
                     });
                 });

--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -13,7 +13,7 @@ import {
 } from "@mui/material";
 
 import {
-    ContactPointSystemKind, IBundle_Entry,
+    IBundle_Entry,
     ICodeableConcept,
     ICoding,
     IContactPoint,
@@ -110,7 +110,8 @@ export default class Summary extends React.Component<SummaryProps, SummaryState>
             let currentSelection = this.state.practitioners.filter(
                 (p: IPractitioner) => {
                     return patient.generalPractitioner?.find((gpRef: IReference) => {
-                        return gpRef.type === "Practitioner" && p.id === gpRef.id;
+                        console.log("ref id ", gpRef.reference)
+                        return gpRef.type === "Practitioner" && gpRef.reference.includes(p.id);
                     });
                 });
             notifyPractitionersSelector = <Autocomplete


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/184838934
Changes include:
- re-arrange components within the messages app to allow the messages be visible within viewport without scrolling.
- re-formatting code
- change position of header banner to `fixed` for it to remain at top when scrolling.
- added patient demographic info, i.e. name and dob at header banner for clinical safety

Example screenshot after changes:
desktop view:
<img width="1244" alt="Screen Shot 2023-03-31 at 5 23 44 PM" src="https://user-images.githubusercontent.com/12942714/229256283-98d96aab-a864-4eb2-950a-1a0214a236f1.png">

mobile view:
<img width="490" alt="Screen Shot 2023-03-31 at 5 20 17 PM" src="https://user-images.githubusercontent.com/12942714/229256300-0184e7e1-c69c-48eb-bd10-634f8c34573e.png">


