### PR TITLE
fix issues for notify on incoming message practitioner selector

### DIFF
--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -1,7 +1,9 @@
 import React, {ReactNode} from 'react';
 import {FhirClientContext} from '../FhirClientContext';
 import {
-    Alert, Autocomplete,
+    Alert,
+    Autocomplete,
+    Chip,
     CircularProgress,
     Table,
     TableBody,
@@ -114,8 +116,13 @@ export default class Summary extends React.Component<SummaryProps, SummaryState>
                     });
                 });
             const selectedPractitionersDisplay = currentSelection.length ?
-                currentSelection.map((p: IPractitioner) => {
-                    return <Typography variant="body2">{this.getPractitionerLabel(p)}</Typography>
+                currentSelection.map((p: IPractitioner, index) => {
+                    return <Chip
+                        key={`notify_p_display_${index}`}
+                        label={this.getPractitionerLabel(p)}
+                        variant="outlined"
+                        sx={{marginBottom: 0.5}}
+                    ></Chip>
                 }) : "None on file";
     
             notifyPractitionersSelector = this.props.editable ? <Autocomplete
@@ -159,7 +166,7 @@ export default class Summary extends React.Component<SummaryProps, SummaryState>
         return <React.Fragment>
             <Typography variant={"h6"}>Recipient info</Typography>
             {patient && <TableContainer>
-                <Table sx={{minWidth: 50}} size={"small"}>
+                <Table sx={{width: "100%"}} size={"small"}>
                     <TableBody>
                         {rows.map((row) => (
                             <TableRow
@@ -169,8 +176,7 @@ export default class Summary extends React.Component<SummaryProps, SummaryState>
                                 <TableCell component="th" scope="row">
                                     {row.label}
                                 </TableCell>
-                                <TableCell align="left" sx={{width: "100%"}}>{row.value}</TableCell>
-
+                                <TableCell align="left">{row.value}</TableCell>
                             </TableRow>
                         ))}
                     </TableBody>

--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -13,7 +13,7 @@ import {
 } from "@mui/material";
 
 import {
-    ContactPointSystemKind, IBundle_Entry,
+    IBundle_Entry,
     ICodeableConcept,
     ICoding,
     IContactPoint,
@@ -110,10 +110,14 @@ export default class Summary extends React.Component<SummaryProps, SummaryState>
             let currentSelection = this.state.practitioners.filter(
                 (p: IPractitioner) => {
                     return patient.generalPractitioner?.find((gpRef: IReference) => {
-                        return gpRef.type === "Practitioner" && p.id === gpRef.id;
+                        return gpRef.type === "Practitioner" && gpRef.reference.includes(p.id);
                     });
                 });
-            notifyPractitionersSelector = <Autocomplete
+            const selectedPractitionersDisplay = currentSelection.map((p: IPractitioner) => {
+                return <Typography variant="body2">{this.getPractitionerLabel(p)}</Typography>
+            });
+    
+            notifyPractitionersSelector = this.props.editable ? <Autocomplete
                 multiple
                 size="small"
                 defaultValue={currentSelection}
@@ -121,12 +125,16 @@ export default class Summary extends React.Component<SummaryProps, SummaryState>
                 getOptionLabel={(option) => this.getPractitionerLabel(option as IPractitioner)}
                 renderInput={(params) => <TextField {...params} placeholder={"Practitioners"}/>}
                 onChange={(event: any, value: (string | IPractitioner)[]) => {
+                    if (!value) {
+                        patient.generalPractitioner = null;
+                        return;
+                    }
                     patient.generalPractitioner = value.map((v) => ({
                         type: "Practitioner",
                         reference: `Practitioner/${(v as IPractitioner).id}`
                     }));
                 }}
-            />;
+            /> : selectedPractitionersDisplay;
         }
 
         let rows = [
@@ -160,7 +168,7 @@ export default class Summary extends React.Component<SummaryProps, SummaryState>
                                 <TableCell component="th" scope="row">
                                     {row.label}
                                 </TableCell>
-                                <TableCell align="left">{row.value}</TableCell>
+                                <TableCell align="left" sx={{width: "100%"}}>{row.value}</TableCell>
 
                             </TableRow>
                         ))}

--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -166,7 +166,7 @@ export default class Summary extends React.Component<SummaryProps, SummaryState>
         return <React.Fragment>
             <Typography variant={"h6"}>Recipient info</Typography>
             {patient && <TableContainer>
-                <Table sx={{width: "100%"}} size={"small"}>
+                <Table sx={{minWidth: 50}} size={"small"}>
                     <TableBody>
                         {rows.map((row) => (
                             <TableRow

--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -5,6 +5,7 @@ import {
     Autocomplete,
     Chip,
     CircularProgress,
+    Stack,
     Table,
     TableBody,
     TableCell,
@@ -115,15 +116,21 @@ export default class Summary extends React.Component<SummaryProps, SummaryState>
                         return gpRef.type === "Practitioner" && gpRef.reference.includes(p.id);
                     });
                 });
-            const selectedPractitionersDisplay = currentSelection.length ?
-                currentSelection.map((p: IPractitioner, index) => {
-                    return <Chip
-                        key={`notify_p_display_${index}`}
-                        label={this.getPractitionerLabel(p)}
-                        variant="outlined"
-                        sx={{marginBottom: 0.5}}
+            const selectedPractitionersDisplay = currentSelection.length ? (
+              <Stack spacing={1}>
+                {currentSelection.map((p: IPractitioner, index) => {
+                  return (
+                    <Chip
+                      key={`notify_p_display_${index}`}
+                      label={this.getPractitionerLabel(p)}
+                      variant="outlined"
                     ></Chip>
-                }) : "None on file";
+                  );
+                })}
+              </Stack>
+            ) : (
+              "None on file"
+            );
     
             notifyPractitionersSelector = this.props.editable ? <Autocomplete
                 multiple

--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -113,9 +113,10 @@ export default class Summary extends React.Component<SummaryProps, SummaryState>
                         return gpRef.type === "Practitioner" && gpRef.reference.includes(p.id);
                     });
                 });
-            const selectedPractitionersDisplay = currentSelection.map((p: IPractitioner) => {
-                return <Typography variant="body2">{this.getPractitionerLabel(p)}</Typography>
-            });
+            const selectedPractitionersDisplay = currentSelection.length ?
+                currentSelection.map((p: IPractitioner) => {
+                    return <Typography variant="body2">{this.getPractitionerLabel(p)}</Typography>
+                }) : "None on file";
     
             notifyPractitionersSelector = this.props.editable ? <Autocomplete
                 multiple


### PR DESCRIPTION
Noticed issue with the UI for selecting practitioner(s) to be notified for incoming message when testing.

Issue - saved practitioners aren't listed as expected
example steps to reproduce: 
- in the enrollment app, select Mary Phipps as the practitioner to be notified
- click Done to close out of enrollment app
- go back to enrollment app
- Mary Phipps isn't listed as expected.
[(see recording)](https://user-images.githubusercontent.com/12942714/231315927-5899e932-3fe6-4c91-bdb8-0361a94ab421.webm)

Changes include 
- fix code for displaying saved general practitioner entries
- add code to display entries when not in edit mode

Other change:
remove unused import, i.e. ContactPointSystemKind
