### PR TITLE
messaging view - display entered by for comment and update display text

### DIFF
--- a/src/components/MessagingView.tsx
+++ b/src/components/MessagingView.tsx
@@ -31,7 +31,7 @@ import {
 import LoadingButton from "@mui/lab/LoadingButton";
 import InfoIcon from "@mui/icons-material/Info";
 import {DateTimePicker} from "@mui/x-date-pickers/DateTimePicker";
-import {grey, lightBlue, yellow} from "@mui/material/colors";
+import {grey, lightBlue, pink, yellow} from "@mui/material/colors";
 import {IsaccMessageCategory} from "../model/CodeSystem";
 import {Error, Refresh, Warning} from "@mui/icons-material";
 import {CommunicationRequest} from "../model/CommunicationRequest";
@@ -620,7 +620,9 @@ export default class MessagingView extends React.Component<
       context.carePlan,
       sentDate,
       receivedDate,
-      IsaccMessageCategory.isaccNonSMSMessage,
+      this.state.activeMessage?.type === "comment"
+        ? IsaccMessageCategory.isaccComment
+        : IsaccMessageCategory.isaccNonSMSMessage,
       noteAboutCommunication
     );
     this._save(newCommunication, (savedResult: IResource) => {
@@ -700,8 +702,12 @@ export default class MessagingView extends React.Component<
     let incoming = true;
     const isNonSmsMessage = !!message.category.find((c: ICodeableConcept) =>
       c.coding.find((coding: ICoding) =>
-        IsaccMessageCategory.isaccNonSMSMessage.equals(coding)
+        IsaccMessageCategory.isaccNonSMSMessage.equals(coding) ||
+        IsaccMessageCategory.isaccComment.equals(coding)
       )
+    );
+    const isComment = !!message.category.find((c: ICodeableConcept) =>
+      c.coding.find((coding: ICoding) => IsaccMessageCategory.isaccComment.equals(coding))
     );
 
     if (isNonSmsMessage) {
@@ -738,7 +744,8 @@ export default class MessagingView extends React.Component<
       incoming,
       autoMessage,
       delivered,
-      isNonSmsMessage
+      isNonSmsMessage,
+      isComment
     );
     let priority = message.priority;
     let themes: string[] = message.getThemes();
@@ -902,8 +909,17 @@ export default class MessagingView extends React.Component<
     incoming: boolean,
     auto: boolean,
     delivered: boolean,
-    info: boolean
+    info: boolean,
+    comment: boolean
   ): object {
+    if (comment)
+      return {
+        backgroundColor: pink[50],
+        borderRadius: 0,
+        color: "#000",
+        boxShadow: `1px 1px 2px ${grey[700]}`,
+        borderBottomRightRadius: "72px 4px"
+      };
     if (info)
       return {
         backgroundColor: yellow[50],

--- a/src/components/MessagingView.tsx
+++ b/src/components/MessagingView.tsx
@@ -38,6 +38,7 @@ import {CommunicationRequest} from "../model/CommunicationRequest";
 import Client from "fhirclient/lib/Client";
 import {Bundle} from "../model/Bundle";
 import {getEnv} from "../util/util";
+import {getUserName } from "../util/isacc_util";
 
 type MessageType = "sms" | "manual message" | "comment";
 type MessageStatus = "sent" | "received";
@@ -344,6 +345,14 @@ export default class MessagingView extends React.Component<
               backgroundColor: "#FFF",
             },
           }}
+          TabScrollButtonProps={{
+            sx: {
+                borderBottom: `2px solid ${grey[200]}`,
+                "&.Mui-disabled": {
+                    width: 0
+                },
+            }
+          }}
           sx={tabRootStyleProps}
         >
           <Tab value="sms" label="ISACC send" {...tabProps} />
@@ -600,7 +609,9 @@ export default class MessagingView extends React.Component<
       this.state.activeMessage?.status === "received"
         ? this.state.activeMessage.date
         : null;
-    const noteAboutCommunication = `non-SMS ${this.state.activeMessage?.type}, staff-entered`;
+    const userName = getUserName(context.client);
+    const enteredByText =  userName ? `entered by ${userName}`: "staff-entered";
+    const noteAboutCommunication = `${this.state.activeMessage?.type}, ${enteredByText}`;
     // new communication
     // TODO implement sender, requires Practitioner resource set for the user
     const newCommunication = Communication.create(
@@ -612,7 +623,6 @@ export default class MessagingView extends React.Component<
       IsaccMessageCategory.isaccNonSMSMessage,
       noteAboutCommunication
     );
-    // save communication
     this._save(newCommunication, (savedResult: IResource) => {
       console.log("Saved new communication:", savedResult);
       const currentMessageType = this.state.activeMessage.type;
@@ -843,6 +853,7 @@ export default class MessagingView extends React.Component<
               color="text.secondary"
               gutterBottom
               sx={{
+                textAlign: "right",
                 whiteSpace: "pre" // preserve line break character
               }}
             >

--- a/src/model/CodeSystem.ts
+++ b/src/model/CodeSystem.ts
@@ -71,6 +71,10 @@ export const IsaccMessageCategory = {
   isaccNonSMSMessage: Coding.make(
     "https://isacc.app/CodeSystem/communication-type",
     "isacc-non-sms-message"
+  ),
+  isaccComment: Coding.make(
+    "https://isacc.app/CodeSystem/communication-type",
+    "isacc-comment"
   )
 };
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/184992691
https://www.pivotaltracker.com/story/show/184992628

Changes include:
- displayed the username for the user that entered the non-sms comment or manual message if available
- fixed display of non-sms messages, i.e. "Non-sms comment" to "comment
- change color of comment box (to pink):
![Screen Shot 2023-04-25 at 5 49 52 PM](https://user-images.githubusercontent.com/12942714/234438381-6c9a4389-97aa-45a5-a28a-fb69a19e7ba5.png)

Other change:
- fix tab scroll button styling in mobile view