### PR TITLE
fix sent message label to distinguish between system sent vs user sent

### DIFF
--- a/src/components/MessagingView.tsx
+++ b/src/components/MessagingView.tsx
@@ -936,7 +936,7 @@ export default class MessagingView extends React.Component<
             incoming
               ? "reply (from recipient)"
               : message.sent
-              ? "response (from author)"
+              ? (autoMessage ? "scheduled Caring Contact message" : "response (from author)")
               : ""
           }`,
         ]


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/185063874
As pointed by Anna, the stackholder, the system sent message is mis-labeled, with `response (from author)`.  This change will fix that.
Screenshot after the fix:
![Screen Shot 2023-04-28 at 12 01 42 PM](https://user-images.githubusercontent.com/12942714/235231542-1663602c-32f8-4834-887e-1c4c505770a5.png)
