### PR TITLE
add no-cache header to requests, rename careplan variable

### DIFF
--- a/src/FhirClientContext.ts
+++ b/src/FhirClientContext.ts
@@ -6,14 +6,14 @@ import CarePlan from "./model/CarePlan";
 export type FhirClientContextType = {
     client: Client;
     patient: Patient;
-    carePlan: CarePlan;
+    currentCarePlan: CarePlan;
     allCarePlans: CarePlan[],
     error: string;
 }
 const defaultValue: FhirClientContextType = {
     client: null,
     patient: null,
-    carePlan: null,
+    currentCarePlan: null,
     allCarePlans: null,
     error: ''
 }

--- a/src/components/MessagingApp.tsx
+++ b/src/components/MessagingApp.tsx
@@ -13,7 +13,7 @@ import DiagnosisAndCareTeam from "./DiagnosisAndCareTeam";
 export const MessagingApp = () => {
   const context = useContext(FhirClientContext);
   let content;
-  if (!context.carePlan) {
+  if (!context.currentCarePlan) {
     content = (
       <Alert severity="error">
         {

--- a/src/components/PatientNotes.tsx
+++ b/src/components/PatientNotes.tsx
@@ -34,7 +34,7 @@ export default class PatientNotes extends React.Component<PatientNotesProps, Pat
         if (this.state.error) return <Alert severity={"error"}>{this.state.error}</Alert>;
 
         // @ts-ignore
-        let carePlan: CarePlan = this.context.carePlan;
+        let carePlan: CarePlan = this.context.currentCarePlan;
 
         if (!carePlan) return null;
 
@@ -94,12 +94,12 @@ export default class PatientNotes extends React.Component<PatientNotesProps, Pat
     private updateNote(updatedPatientNote: string) {
         // @ts-ignore
         let context: FhirClientContextType = this.context;
-        let carePlan = context.carePlan;
+        let carePlan = context.currentCarePlan;
         carePlan.description = updatedPatientNote;
         context.client.update(carePlan).then(
             (result: any) => {
-                context.carePlan = CarePlan.from(result as ICarePlan);
-                console.log("Updated CarePlan:", context.carePlan);
+                context.currentCarePlan = CarePlan.from(result as ICarePlan);
+                console.log("Updated CarePlan:", context.currentCarePlan);
                 this.setState({
                     editable: false,
                     updatedPatientNote: null

--- a/src/components/ScheduleSetup.tsx
+++ b/src/components/ScheduleSetup.tsx
@@ -83,7 +83,6 @@ export default class ScheduleSetup extends React.Component<ScheduleSetupProps, S
     componentDidMount() {
         //@ts-ignore
         let carePlan: CarePlan = this.context.currentCarePlan;
-        console.log("current careplan ", carePlan)
         this.setState({carePlan: carePlan});
     }
 
@@ -310,7 +309,6 @@ export default class ScheduleSetup extends React.Component<ScheduleSetupProps, S
                 p = client.create(this.state.carePlan);
             }
             p.then((savedCarePlan: IResource) => {
-                console.log("savedCarePlan ", savedCarePlan)
                 this.onSaved(savedCarePlan);
                 let updatePromises = communicationRequests.map((c: CommunicationRequest) => {
                     c.basedOn = [{reference: `CarePlan/${savedCarePlan.id}`}];

--- a/src/components/ScheduleSetup.tsx
+++ b/src/components/ScheduleSetup.tsx
@@ -35,6 +35,7 @@ import Client from "fhirclient/lib/Client";
 import PatientNotes from "./PatientNotes";
 import CarePlan from "../model/CarePlan";
 import {Bundle} from "../model/Bundle";
+import { getFhirData } from "../util/isacc_util";
 
 
 interface ScheduleSetupProps {
@@ -81,7 +82,8 @@ export default class ScheduleSetup extends React.Component<ScheduleSetupProps, S
 
     componentDidMount() {
         //@ts-ignore
-        let carePlan: CarePlan = this.context.carePlan;
+        let carePlan: CarePlan = this.context.currentCarePlan;
+        console.log("current careplan ", carePlan)
         this.setState({carePlan: carePlan});
     }
 
@@ -171,8 +173,11 @@ export default class ScheduleSetup extends React.Component<ScheduleSetupProps, S
                     <DialogActions>
                         <Button
                             onClick={onClose}
-                            href={clearSessionLink} autoFocus>Close schedule planner</Button>
-
+                            href={clearSessionLink}
+                            variant="contained"
+                        >
+                            Close schedule planner
+                        </Button>
                     </DialogActions>
                 </DialogContent>
             </Dialog>;
@@ -207,7 +212,7 @@ export default class ScheduleSetup extends React.Component<ScheduleSetupProps, S
             // "_id:not: `${patient.id}`"  // this DOES NOT WORK, at least when tried against SMIT, R4 FHIR server 
             // need to figure out the correct search paramter for excluding a patient id
         }).toString();
-        return client.request(`/Patient?${params}`).then((bundle: Bundle): Promise<void> => {
+        return getFhirData(client, `/Patient?${params}`).then((bundle: Bundle): Promise<void> => {
             return new Promise((resolve, reject) => {
                 if (bundle.type === "searchset") {
                     if (bundle.entry) {
@@ -305,6 +310,7 @@ export default class ScheduleSetup extends React.Component<ScheduleSetupProps, S
                 p = client.create(this.state.carePlan);
             }
             p.then((savedCarePlan: IResource) => {
+                console.log("savedCarePlan ", savedCarePlan)
                 this.onSaved(savedCarePlan);
                 let updatePromises = communicationRequests.map((c: CommunicationRequest) => {
                     c.basedOn = [{reference: `CarePlan/${savedCarePlan.id}`}];

--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -28,7 +28,8 @@ import {RelationshipCategory} from "../model/CodeSystem";
 import Patient from "../model/Patient";
 import Client from "fhirclient/lib/Client";
 import {Bundle} from "../model/Bundle";
-import { AsYouType, isPossiblePhoneNumber,parsePhoneNumber } from 'libphonenumber-js'
+import { AsYouType, isPossiblePhoneNumber,parsePhoneNumber } from 'libphonenumber-js';
+import { getFhirData } from '../util/isacc_util';
 
 interface SummaryProps {
     editable: boolean
@@ -65,7 +66,7 @@ export default class Summary extends React.Component<SummaryProps, SummaryState>
       _count: "250",
       _sort: "-_lastUpdated",
     }).toString();
-    client.request(`/Practitioner?${params}`).then((bundle: Bundle) => {
+    getFhirData(client, `/Practitioner?${params}`).then((bundle: Bundle) => {
       console.log("Loaded practitioners", bundle);
       const entries = bundle?.entry?.map(
         (e: IBundle_Entry) => e.resource as IPractitioner

--- a/src/util/isacc_util.ts
+++ b/src/util/isacc_util.ts
@@ -34,3 +34,12 @@ export function getUserEmail(client: Client) {
     if (token['email']) return token['email'];
     return null;
 }
+
+export function getFhirData(client: Client, url: string, signal: AbortSignal = null) {
+  return client?.request({
+    url: url,
+    headers: {
+      "Cache-Control": "no-cache",
+    },
+  });
+}


### PR DESCRIPTION
Add no-cache header to requests, i.e. Patient, Communications, CommunicationRequests, to ensure that search results contain the latest updates.  Attempt to address some of the issues that Kate mentioned.  see [Slack convo](https://cirg.slack.com/archives/C051K8WL1CP/p1682798213003269)

Other change -
rename context variable, `carePlan` to `currentCarePlan` to better reflect its meaning per feedback