### PR TITLE
Allow retroactive changes to manual message and comment in Messaging view

### DIFF
--- a/src/components/MessagingView.tsx
+++ b/src/components/MessagingView.tsx
@@ -1196,6 +1196,7 @@ export default class MessagingView extends React.Component<
             {editable && (
               <IconButton
                 size="small"
+                title="Edit"
                 onClick={() => {
                   this.setState({
                     editEntry: message,

--- a/src/components/MessagingView.tsx
+++ b/src/components/MessagingView.tsx
@@ -137,32 +137,32 @@ export default class MessagingView extends React.Component<
     let context: FhirClientContextType = this.context;
     this.setState({ messagesLoading: true });
 
-    const carePlanIds = context.allCarePlans?.map((item) => item.id);
+    const carePlanIds = context.allCarePlans?.map(item => item.id)
 
     this.getCommunications(context.client, carePlanIds, url)
       .then(
         (result: Communication[]) => {
-          const uniqueResults = (result ?? []).filter((item) => {
-            const currentSet = this.state.communications ?? [];
-            return !currentSet.find((o) => o.id === item.id);
-          });
-          const allResults = [
-            ...(this.state.communications ?? []),
-            ...uniqueResults,
-          ];
-          let temporaryCommunications =
-            this.state.temporaryCommunications.filter((tc: Communication) => {
-              return !allResults?.find((c: Communication) => {
-                return c.basedOn?.find((b: IReference) => {
-                  return b.reference?.split("/")[1] === tc.id;
+            const uniqueResults = (result ?? []).filter((item) => {
+              const currentSet = this.state.communications ?? [];
+              return !currentSet.find((o) => o.id === item.id);
+            });
+            const allResults = [
+              ...(this.state.communications ?? []),
+              ...uniqueResults,
+            ];
+            let temporaryCommunications =
+              this.state.temporaryCommunications.filter((tc: Communication) => {
+                return !allResults?.find((c: Communication) => {
+                  return c.basedOn?.find((b: IReference) => {
+                    return b.reference?.split("/")[1] === tc.id;
+                  });
                 });
               });
+            this.setState({
+              communications: allResults,
+              messagesLoading: false,
+              temporaryCommunications: temporaryCommunications,
             });
-          this.setState({
-            communications: allResults,
-            messagesLoading: false,
-            temporaryCommunications: temporaryCommunications,
-          });
         },
         (reason: any) =>
           this.setState({ error: reason, messagesLoading: false })
@@ -182,48 +182,48 @@ export default class MessagingView extends React.Component<
     // Communication?part-of=CarePlan/${id1}[,CarePlan/${id2}]
     // get communications for all care plans for the patient
     let params = new URLSearchParams({
-      "part-of": carePlanIds?.map((item) => `CarePlan/${item}`).join(","),
-      _count: "200",
-    }).toString();
-    const requestURL = url ? url : `/Communication?${params}`;
+        "part-of": carePlanIds?.map(item =>`CarePlan/${item}`).join(","),
+        _count: "200"
+      }).toString();
+    const requestURL = url ? url : `/Communication?${params}`
     return await getFhirData(client, requestURL, signal).then(
-      (bundle: Bundle) => {
-        if (bundle.type === "searchset") {
-          if (!bundle.entry) return [];
-          let nextPageURL: string = null;
-          if (bundle.link && bundle.link.length > 0) {
-            const arrNextURL = bundle.link.filter(
-              (item) => item.relation === "next"
-            );
-            nextPageURL = arrNextURL.length > 0 ? arrNextURL[0].url : null;
-          }
-          let communications: Communication[] = bundle.entry.map(
-            (e: IBundle_Entry) => {
-              if (e.resource.resourceType !== "Communication") {
-                this.setState({ error: "Unexpected resource type returned" });
-                return null;
-              } else {
-                console.log("Communication loaded:", e);
-                return Communication.from(e.resource);
-              }
+        (bundle: Bundle) => {
+          if (bundle.type === "searchset") {
+            if (!bundle.entry) return [];
+            let nextPageURL:string = null;
+            if (bundle.link && bundle.link.length > 0) {
+              const arrNextURL = bundle.link.filter(
+                (item) => item.relation === "next"
+              );
+              nextPageURL = arrNextURL.length > 0 ? arrNextURL[0].url : null;
             }
-          );
-          if (nextPageURL !== this.state.nextPageURL) {
-            this.setState({
-              nextPageURL: nextPageURL,
-            });
+            let communications: Communication[] = bundle.entry.map(
+              (e: IBundle_Entry) => {
+                if (e.resource.resourceType !== "Communication") {
+                  this.setState({ error: "Unexpected resource type returned" });
+                  return null;
+                } else {
+                  console.log("Communication loaded:", e);
+                  return Communication.from(e.resource);
+                }
+              }
+            );
+            if (nextPageURL !== this.state.nextPageURL) {
+                this.setState({
+                    nextPageURL: nextPageURL
+                });
+            }
+            return communications;
+          } else {
+            this.setState({ error: "Unexpected bundle type returned" });
+            return null;
           }
-          return communications;
-        } else {
-          this.setState({ error: "Unexpected bundle type returned" });
+        },
+        (reason: any) => {
+          this.setState({ error: reason.toString() });
           return null;
         }
-      },
-      (reason: any) => {
-        this.setState({ error: reason.toString() });
-        return null;
-      }
-    );
+      );
   }
 
   render(): React.ReactNode {
@@ -387,7 +387,7 @@ export default class MessagingView extends React.Component<
     const tabRootStyleProps = {
       margin: {
         xs: "8px auto 0",
-        sm: "8px 0 0",
+        sm: "8px 0 0"
       },
       marginTop: 1,
       minHeight: "40px",
@@ -411,7 +411,7 @@ export default class MessagingView extends React.Component<
     const tabProps = {
       sx: {
         padding: {
-          sm: (theme: any) => theme.spacing(1, 2.5),
+          sm: (theme: any) => theme.spacing(1, 2.5)
         },
       },
     };
@@ -424,11 +424,7 @@ export default class MessagingView extends React.Component<
           value={this.state.activeMessage?.type}
           onChange={(event: React.SyntheticEvent, value: MessageType) => {
             this.setState({
-              activeMessage: {
-                ...defaultMessage,
-                type: value,
-                date: new Date().toISOString(),
-              },
+              activeMessage: { ...defaultMessage, type: value, date: new Date().toISOString()},
             });
           }}
           textColor="primary"
@@ -602,7 +598,6 @@ export default class MessagingView extends React.Component<
                   <TextField
                     {...params}
                     onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                      console.log("target? ", event.target);
                       if (MessagingView.isValidDate(event.target.value)) {
                         this.setState({
                           activeMessage: {
@@ -1081,9 +1076,7 @@ export default class MessagingView extends React.Component<
             incoming
               ? "reply (from recipient)"
               : message.sent
-              ? autoMessage
-                ? "scheduled Caring Contact message"
-                : "response (from author)"
+              ? (autoMessage ? "scheduled Caring Contact message" : "response (from author)")
               : ""
           }`,
         ]

--- a/src/components/PatientNotes.tsx
+++ b/src/components/PatientNotes.tsx
@@ -3,6 +3,7 @@ import {FhirClientContext, FhirClientContextType} from '../FhirClientContext';
 import {Alert, Button, CardActions, CardContent, CircularProgress, TextField, Typography} from "@mui/material";
 import CarePlan from "../model/CarePlan";
 import {ICarePlan} from "@ahryman40k/ts-fhir-types/lib/R4";
+import EditIcon from "@mui/icons-material/Edit";
 
 interface PatientNotesProps {
 
@@ -74,6 +75,7 @@ export default class PatientNotes extends React.Component<PatientNotesProps, Pat
                 }}
                 size="small"
                 variant="outlined"
+                startIcon={<EditIcon></EditIcon>}
               >
                 {this.state.editable ? "Done" : "Update"}
               </Button>


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/185091681
Changes include:
- allow retroactive editing of existing manual message or comment, as signified by the pencil icon (see screenshot):

![screenshot of UI](https://user-images.githubusercontent.com/12942714/236268713-40ac3867-acc2-4210-9c3c-f4eceea71f4f.png)
when the edit icon is clicked:
![Screen Shot 2023-05-04 at 9 20 07 AM](https://user-images.githubusercontent.com/12942714/236269083-e6fc18fb-18e8-42ae-b9b9-37c482b0a46d.png)


**NOTE**, this will only allow editing of comment and manual message(s) authored by the user him/herself
