### PR TITLE
remove PROS, recipient info(diagnostic team) sections as per Kate's request

### DIFF
--- a/src/components/MessagingApp.tsx
+++ b/src/components/MessagingApp.tsx
@@ -2,13 +2,11 @@ import { AppPageScaffold } from "./AppPage";
 import { Grid, GridProps, Paper, Stack } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import Summary from "./Summary";
-import PatientPROs from "./PatientPROs";
 import PatientNotes from "./PatientNotes";
 import MessageView from "./MessagingView";
 import React, { PropsWithChildren, useContext } from "react";
 import { FhirClientContext } from "../FhirClientContext";
 import Alert from "@mui/material/Alert";
-import DiagnosisAndCareTeam from "./DiagnosisAndCareTeam";
 
 export const MessagingApp = () => {
   const context = useContext(FhirClientContext);
@@ -35,9 +33,6 @@ export const MessagingApp = () => {
             <Item>
               <Summary editable={false} />
             </Item>
-            <Item>
-              <PatientNotes />
-            </Item>
           </Stack>
         </GridItem>
         <GridItem xs={12} sm={12} md={6} lg={6} xl={6}>
@@ -46,14 +41,9 @@ export const MessagingApp = () => {
           </Item>
         </GridItem>
         <GridItem xs={12} sm={12} md={3} lg={3} xl={3}>
-          <Stack direction={"column"} spacing={1} sx={{ width: "100%" }}>
             <Item>
-              <DiagnosisAndCareTeam />
+              <PatientNotes />
             </Item>
-            <Item>
-              <PatientPROs />
-            </Item>
-          </Stack>
         </GridItem>
       </Grid>
     );


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/184992746
Remove these from Messaging Client: "Recipient info" ("No diagnosis or care team information on file"), QuestionnaireResponse section (PHQ, etc).
Per 2023-04-19 meeting w/ Kate.