### PR TITLE
add keyup event listener to date/time field in edit dialog for comment/manual message

### DIFF
--- a/src/components/MessagingView.tsx
+++ b/src/components/MessagingView.tsx
@@ -730,6 +730,15 @@ export default class MessagingView extends React.Component<
                         targetEntry[dateFieldName] = newValue;
                       }
                     }}
+                    onKeyUp={(event: React.KeyboardEvent<HTMLInputElement>) => {
+                      const inputValue = (event.target as HTMLInputElement).value;
+                      if (MessagingView.isValidDate(inputValue)) {
+                        const newValue = new Date(
+                          inputValue
+                        ).toISOString();
+                        targetEntry[dateFieldName] = newValue;
+                      }
+                    }}
                   ></TextField>
                 )}
                 onChange={(newValue: Date | null) => {


### PR DESCRIPTION
responding to feedback from story:  https://www.pivotaltracker.com/story/show/185091681
`I am able to edit the time to be in the future without an error message and hit the save button, however the edit does not successfully save.`

It seemed to save for me if selecting date from datepicker or changing date/time and then **removing** focus from field.
It didn't save if I merely changed the date and/or time without removing focus from the date/time field.

This is to address that by adding a keyup event listener to the textfield.