### PR TITLE
Non-SMS manual message/comment - display authored by practitioner name

### DIFF
--- a/src/FhirClientProvider.tsx
+++ b/src/FhirClientProvider.tsx
@@ -121,6 +121,7 @@ export default function FhirClientProvider(props: Props): JSX.Element {
             const resourceResult = result.value;
             const resourceType = resourceResult?.resourceType;
             if (resourceType === "Practitioner") {
+              console.log("Loaded practitioner ", resourceResult);
               setPractitioner(resourceResult);
             } else if (resourceType === "Patient") {
               setPatient(resourceResult);

--- a/src/components/MessagingView.tsx
+++ b/src/components/MessagingView.tsx
@@ -957,10 +957,20 @@ export default class MessagingView extends React.Component<
       this.state.activeMessage?.status === "received"
         ? this.state.activeMessage.date
         : null;
-    const userName = getUserName(context.client);
-    const enteredByText = userName ? `entered by ${userName}` : "staff-entered";
-    const noteAboutCommunication = `${this.state.activeMessage?.type}, ${enteredByText}`;
     const currentPractitioner = context.practitioner;
+    const userName = getUserName(context.client);
+    const practitionerName = currentPractitioner
+      ? [
+          currentPractitioner.firstName,
+          currentPractitioner.lastName?.charAt(0) || "",
+        ].join(" ")
+      : "";
+    const enteredByText = practitionerName
+      ? `entered by ${practitionerName}`
+      : userName
+      ? `entered by ${userName}`
+      : "staff-entered";
+    const noteAboutCommunication = `${this.state.activeMessage?.type}, ${enteredByText}`;
     // new communication
     // TODO implement sender, requires Practitioner resource set for the user
     const newCommunication = Communication.create(
@@ -1138,8 +1148,22 @@ export default class MessagingView extends React.Component<
     let isEditable = isNonSmsMessage || isComment;
     // @ts-ignore
     const userName = getUserName(this.context.client);
+
+    // @ts-ignore
+    const currentPractitioner = this.context.practitioner;
+    const referenceId = message?.sender?.reference.split("/")[1];
+    // practitioner info is available, user can only edit a manual message or comment authored by him/herself
+    if (
+      currentPractitioner &&
+      message.sender &&
+      message.sender.reference &&
+      message.sender.reference.toLowerCase().includes("practitioner") &&
+      referenceId
+    ) {
+      isEditable = isEditable && referenceId === currentPractitioner.id;
+    }
     // username is available, user can only edit a manual message or comment authored by him/herself
-    if (userName) isEditable = isEditable && note.includes(userName);
+    else if (userName) isEditable = isEditable && note.includes(userName);
 
     return this._alignedRow(
       incoming,


### PR DESCRIPTION
For Non-SMS manual message/comment, if practitioner info is available, display `entered by` text followed by practitioner first name and last name initial.
part of https://www.pivotaltracker.com/story/show/185306799