### PR TITLE
allow line break(s) in patient note

### DIFF
--- a/src/components/PatientNotes.tsx
+++ b/src/components/PatientNotes.tsx
@@ -48,6 +48,7 @@ export default class PatientNotes extends React.Component<PatientNotesProps, Pat
                   InputProps={{ sx: { typography: "body1" } }}
                   multiline
                   fullWidth
+                  minRows={4}
                   value={this.state.updatedPatientNote ?? ""}
                   placeholder={"Enter recipient note"}
                   onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
@@ -55,7 +56,7 @@ export default class PatientNotes extends React.Component<PatientNotesProps, Pat
                   }}
                 />
               ) : (
-                <Typography variant={"body1"} sx={{padding: (theme) => theme.spacing(1)}}>
+                <Typography variant={"body1"} sx={{padding: (theme) => theme.spacing(1), whiteSpace: "pre-wrap"}}>
                   {carePlan.description}
                 </Typography>
               )}

--- a/src/components/ScheduleSetup.tsx
+++ b/src/components/ScheduleSetup.tsx
@@ -114,6 +114,7 @@ export default class ScheduleSetup extends React.Component<ScheduleSetupProps, S
                                     sx={{maxHeight: 400, overflow: 'auto', ...styles.patientNotesField}}
                                     fullWidth
                                     multiline
+                                    minRows={4}
                                     value={this.state.carePlan.description ?? ""}
                                     placeholder={"Recipient note"}
                                     onChange={(event: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
For readability, allow patient note to have line breaks.

Screenshots after the change:
![Screen Shot 2023-06-14 at 4 27 02 PM](https://github.com/uwcirg/isacc-messaging-client-sof/assets/12942714/cc70d11f-612a-4f74-91f5-bd068d3ecbf6)
![Screen Shot 2023-06-14 at 4 27 10 PM](https://github.com/uwcirg/isacc-messaging-client-sof/assets/12942714/82dc0cb8-0edf-4f80-97b4-0bfaaa858174)
