### PR TITLE
Enrollment App bug fix - edit button not working when request for communicationRequests return empty array

### DIFF
--- a/src/FhirClientProvider.tsx
+++ b/src/FhirClientProvider.tsx
@@ -103,7 +103,7 @@ export default function FhirClientProvider(props: Props): JSX.Element {
     const searchParams = new URLSearchParams({
       category: IsaccCarePlanCategory.isaccMessagePlan.code,
       subject: `Patient/${patientId}`,
-      _sort: "-_lastUpdated",
+      _sort: "-_id",
     }).toString();
     return getFhirData(client, `/CarePlan?${searchParams}`).then(
       (bundle: Bundle) => {

--- a/src/components/EnrollmentApp.tsx
+++ b/src/components/EnrollmentApp.tsx
@@ -157,8 +157,10 @@ export default class EnrollmentApp extends React.Component<{}, EnrollmenAppState
         }).toString();
         getFhirData(client,`CommunicationRequest?${params}`).then((bundle: Bundle) => {
             if (bundle.type === "searchset") {
-                if (!bundle.entry) return [];
-
+                if (!bundle.entry) {
+                    this.setState({editMode: true});
+                    return [];
+                }
                 let crs: CommunicationRequest[] = bundle.entry.map((e: IBundle_Entry) => {
                     if (e.resource.resourceType !== "CommunicationRequest") {
                         this.setState({error: "Unexpected resource type returned"});
@@ -217,6 +219,7 @@ export default class EnrollmentApp extends React.Component<{}, EnrollmenAppState
                 Revoke and create new
               </Button>
             </Stack>
+            {this.state.error && <Alert severity="error">{this.state.error}</Alert>}
           </Stack>
         );
 


### PR DESCRIPTION
I believe this is the issue with Anna's patient on eval ( communication requests [here](https://fhir.isacc.eval.cirg.uw.edu/fhir/CommunicationRequest?recipient=Patient%2F705&based-on=CarePlan%2F714&category=isacc-scheduled-message) )
The code prematurely returns without setting the state variable `EditMode` to true - which prevents the UI edits elements to render - as it normally would when you click on the Edit button.