### PR TITLE
Tailors the site-specific PlanDefinitions for each site...

### DIFF
--- a/src/fhir/PlanDefinition_opc.json
+++ b/src/fhir/PlanDefinition_opc.json
@@ -77,7 +77,7 @@
       "timingTiming": {
         "repeat": {
           "frequency": 1,
-          "period": 8,
+          "period": 7,
           "periodUnit": "d",
           "timeOfDay": [
             "08:31:00"
@@ -103,7 +103,7 @@
       "timingTiming": {
         "repeat": {
           "frequency": 1,
-          "period": 15,
+          "period": 14,
           "periodUnit": "d",
           "timeOfDay": [
             "08:47:00"
@@ -129,7 +129,7 @@
       "timingTiming": {
         "repeat": {
           "frequency": 1,
-          "period": 22,
+          "period": 21,
           "periodUnit": "d",
           "timeOfDay": [
             "08:35:00"
@@ -155,7 +155,7 @@
       "timingTiming": {
         "repeat": {
           "frequency": 1,
-          "period": 36,
+          "period": 35,
           "periodUnit": "d",
           "timeOfDay": [
             "09:02:00"
@@ -181,7 +181,7 @@
       "timingTiming": {
         "repeat": {
           "frequency": 1,
-          "period": 50,
+          "period": 49,
           "periodUnit": "d",
           "timeOfDay": [
             "08:40:00"
@@ -207,7 +207,7 @@
       "timingTiming": {
         "repeat": {
           "frequency": 1,
-          "period": 64,
+          "period": 63,
           "periodUnit": "d",
           "timeOfDay": [
             "08:53:00"
@@ -233,7 +233,7 @@
       "timingTiming": {
         "repeat": {
           "frequency": 1,
-          "period": 78,
+          "period": 77,
           "periodUnit": "d",
           "timeOfDay": [
             "08:42:00"

--- a/src/fhir/PlanDefinition_opc.json
+++ b/src/fhir/PlanDefinition_opc.json
@@ -8,12 +8,6 @@
       "definitionCanonical": "#Day0Msg0"
     },
     {
-      "definitionCanonical": "#Day0Msg1"
-    },
-    {
-      "definitionCanonical": "#Day0Msg2"
-    },
-    {
       "definitionCanonical": "#Day7Msg0"
     },
     {
@@ -69,59 +63,7 @@
           "path": "payload.contentString",
           "expression": {
             "language": "text/cql",
-            "expression": "Thank you for signing up for the Caring Contacts study at OPC {name}! Can you please respond to let us know you received this message? -OPC care team"
-          }
-        }
-      ]
-    },
-    {
-      "resourceType": "ActivityDefinition",
-      "id": "Day0Msg1",
-      "name": "Day 0 Message 1",
-      "status": "active",
-      "kind": "CommunicationRequest",
-      "timingTiming": {
-        "repeat": {
-          "frequency": 1,
-          "period": 1,
-          "periodUnit": "d",
-          "timeOfDay": [
-            "18:01:00"
-          ]
-        }
-      },
-      "dynamicValue": [
-        {
-          "path": "payload.contentString",
-          "expression": {
-            "language": "text/cql",
-            "expression": "As a reminder, we're here and will respond when the clinic is open Mon-Fri 8-5."
-          }
-        }
-      ]
-    },
-    {
-      "resourceType": "ActivityDefinition",
-      "id": "Day0Msg2",
-      "name": "Day 0 Message 2",
-      "status": "active",
-      "kind": "CommunicationRequest",
-      "timingTiming": {
-        "repeat": {
-          "frequency": 1,
-          "period": 1,
-          "periodUnit": "d",
-          "timeOfDay": [
-            "18:01:00"
-          ]
-        }
-      },
-      "dynamicValue": [
-        {
-          "path": "payload.contentString",
-          "expression": {
-            "language": "text/cql",
-            "expression": "If you need help on the evening or weekends, you might start here https://988lifeline.org/help-yourself/ -OPC care team"
+            "expression": "Thank you for signing up for the Caring Contacts study at OPC {name}! Can you please respond to let us know you received this message? As a reminder, we're here and will respond when the clinic is open Mon-Fri 8-5. If you need help in the evening or weekends, you might start here https://988lifeline.org/help-yourself/ -OPC care team"
           }
         }
       ]
@@ -151,6 +93,7 @@
           }
         }
       ]
+    },
     {
       "resourceType": "ActivityDefinition",
       "id": "Day14Msg0",
@@ -176,6 +119,7 @@
           }
         }
       ]
+    },
     {
       "resourceType": "ActivityDefinition",
       "id": "Day21Msg0",
@@ -201,6 +145,7 @@
           }
         }
       ]
+    },
     {
       "resourceType": "ActivityDefinition",
       "id": "Day35Msg0",
@@ -304,6 +249,7 @@
           }
         }
       ]
+    },
     {
       "resourceType": "ActivityDefinition",
       "id": "AutumnMsg",

--- a/src/fhir/PlanDefinition_opc.json
+++ b/src/fhir/PlanDefinition_opc.json
@@ -5,28 +5,37 @@
   "status": "active",
   "action": [
     {
-      "definitionCanonical": "#Week0Day0Msg"
+      "definitionCanonical": "#Day0Msg0"
     },
     {
-      "definitionCanonical": "#Week0Day1Msg"
+      "definitionCanonical": "#Day0Msg1"
     },
     {
-      "definitionCanonical": "#Week0Day2Msg"
+      "definitionCanonical": "#Day0Msg2"
     },
     {
-      "definitionCanonical": "#Week0Day3Msg"
+      "definitionCanonical": "#Day7Msg0"
     },
     {
-      "definitionCanonical": "#Week0Day5Msg"
+      "definitionCanonical": "#Day14Msg0"
     },
     {
-      "definitionCanonical": "#Week1Day0Msg"
+      "definitionCanonical": "#Day21Msg0"
     },
     {
-      "definitionCanonical": "#Week1Day2Msg"
+      "definitionCanonical": "#Day35Msg0"
     },
     {
-      "definitionCanonical": "#Week1Day4Msg"
+      "definitionCanonical": "#Day49Msg0"
+    },
+    {
+      "definitionCanonical": "#Day63Msg0"
+    },
+    {
+      "definitionCanonical": "#Day77Msg0"
+    },
+    {
+      "definitionCanonical": "#AutumnMsg"
     },
     {
       "definitionCanonical": "#BirthdayMsg",
@@ -41,8 +50,8 @@
   "contained": [
     {
       "resourceType": "ActivityDefinition",
-      "id": "Week0Day0Msg",
-      "name": "Week 0 Day 0 Message",
+      "id": "Day0Msg0",
+      "name": "Day 0 Message 0",
       "status": "active",
       "kind": "CommunicationRequest",
       "timingTiming": {
@@ -51,7 +60,7 @@
           "period": 0,
           "periodUnit": "d",
           "timeOfDay": [
-            "13:30:00"
+            "18:00:00"
           ]
         }
       },
@@ -67,8 +76,8 @@
     },
     {
       "resourceType": "ActivityDefinition",
-      "id": "Week0Day1Msg",
-      "name": "Week 0 Day 1 Message",
+      "id": "Day0Msg1",
+      "name": "Day 0 Message 1",
       "status": "active",
       "kind": "CommunicationRequest",
       "timingTiming": {
@@ -77,7 +86,7 @@
           "period": 1,
           "periodUnit": "d",
           "timeOfDay": [
-            "08:30:00"
+            "18:01:00"
           ]
         }
       },
@@ -86,24 +95,24 @@
           "path": "payload.contentString",
           "expression": {
             "language": "text/cql",
-            "expression": "Hi there {name}, Hope you are having a good day.  I am here for you if you need me. {userName}"
+            "expression": "As a reminder, we're here and will respond when the clinic is open Mon-Fri 8-5."
           }
         }
       ]
     },
     {
       "resourceType": "ActivityDefinition",
-      "id": "Week0Day2Msg",
-      "name": "Week 0 Day 2 Message",
+      "id": "Day0Msg2",
+      "name": "Day 0 Message 2",
       "status": "active",
       "kind": "CommunicationRequest",
       "timingTiming": {
         "repeat": {
           "frequency": 1,
-          "period": 2,
+          "period": 1,
           "periodUnit": "d",
           "timeOfDay": [
-            "12:00:00"
+            "18:01:00"
           ]
         }
       },
@@ -112,24 +121,24 @@
           "path": "payload.contentString",
           "expression": {
             "language": "text/cql",
-            "expression": "Hi {name} - You made your first steps. Don't give up now {userName}"
+            "expression": "If you need help on the evening or weekends, you might start here https://988lifeline.org/help-yourself/ -OPC care team"
           }
         }
       ]
     },
     {
       "resourceType": "ActivityDefinition",
-      "id": "Week0Day3Msg",
-      "name": "Week 0 Day 3 Message",
+      "id": "Day7Msg0",
+      "name": "Day 7 Message 0",
       "status": "active",
       "kind": "CommunicationRequest",
       "timingTiming": {
         "repeat": {
           "frequency": 1,
-          "period": 3,
+          "period": 8,
           "periodUnit": "d",
           "timeOfDay": [
-            "11:20:00"
+            "08:31:00"
           ]
         }
       },
@@ -138,24 +147,99 @@
           "path": "payload.contentString",
           "expression": {
             "language": "text/cql",
-            "expression": "Hello {name}, I know life can be difficult sometimes; I just want you to know that I'm thinking about you and sending positive thoughts your way.  Sincerely, {userName}  "
+            "expression": "We are thinking of you and hope you have a great day {name}! -OPC care team"
+          }
+        }
+      ]
+    {
+      "resourceType": "ActivityDefinition",
+      "id": "Day14Msg0",
+      "name": "Day 14 Message 0",
+      "status": "active",
+      "kind": "CommunicationRequest",
+      "timingTiming": {
+        "repeat": {
+          "frequency": 1,
+          "period": 15,
+          "periodUnit": "d",
+          "timeOfDay": [
+            "08:47:00"
+          ]
+        }
+      },
+      "dynamicValue": [
+        {
+          "path": "payload.contentString",
+          "expression": {
+            "language": "text/cql",
+            "expression": "Sending good thoughts and energy your way! -OPC care team"
+          }
+        }
+      ]
+    {
+      "resourceType": "ActivityDefinition",
+      "id": "Day21Msg0",
+      "name": "Day 21 Message 0",
+      "status": "active",
+      "kind": "CommunicationRequest",
+      "timingTiming": {
+        "repeat": {
+          "frequency": 1,
+          "period": 22,
+          "periodUnit": "d",
+          "timeOfDay": [
+            "08:35:00"
+          ]
+        }
+      },
+      "dynamicValue": [
+        {
+          "path": "payload.contentString",
+          "expression": {
+            "language": "text/cql",
+            "expression": "Life can be difficult at times. We are cheering for you {name}! -OPC care team"
+          }
+        }
+      ]
+    {
+      "resourceType": "ActivityDefinition",
+      "id": "Day35Msg0",
+      "name": "Day 35 Message 0",
+      "status": "active",
+      "kind": "CommunicationRequest",
+      "timingTiming": {
+        "repeat": {
+          "frequency": 1,
+          "period": 36,
+          "periodUnit": "d",
+          "timeOfDay": [
+            "09:02:00"
+          ]
+        }
+      },
+      "dynamicValue": [
+        {
+          "path": "payload.contentString",
+          "expression": {
+            "language": "text/cql",
+            "expression": "Did you know that exercise can be helpful for treating depression? If you’re feeling low, even 10 minutes of walking can release those feel-good endorphins. -OPC care team"
           }
         }
       ]
     },
     {
       "resourceType": "ActivityDefinition",
-      "id": "Week0Day5Msg",
-      "name": "Week 0 Day 5 Message",
+      "id": "Day49Msg0",
+      "name": "Day 49 Message 0",
       "status": "active",
       "kind": "CommunicationRequest",
       "timingTiming": {
         "repeat": {
           "frequency": 1,
-          "period": 5,
+          "period": 50,
           "periodUnit": "d",
           "timeOfDay": [
-            "19:03:00"
+            "08:40:00"
           ]
         }
       },
@@ -164,24 +248,24 @@
           "path": "payload.contentString",
           "expression": {
             "language": "text/cql",
-            "expression": "Hey {name}, hope things are going well and you're having a good week. - {userName}"
+            "expression": "It’s a beautiful day to be alive {name}! Thinking of you today! -OPC care team"
           }
         }
       ]
     },
     {
       "resourceType": "ActivityDefinition",
-      "id": "Week1Day0Msg",
-      "name": "Week 1 Day 0 Message",
+      "id": "Day63Msg0",
+      "name": "Day 63 Message 0",
       "status": "active",
       "kind": "CommunicationRequest",
       "timingTiming": {
         "repeat": {
           "frequency": 1,
-          "period": 7,
+          "period": 64,
           "periodUnit": "d",
           "timeOfDay": [
-            "16:24:00"
+            "08:53:00"
           ]
         }
       },
@@ -190,24 +274,24 @@
           "path": "payload.contentString",
           "expression": {
             "language": "text/cql",
-            "expression": "Hi {name}, hope all's well and you're taking good care of yourself {userName}"
+            "expression": "We hope this message finds you well, {name}. Sending positive vibes your way. -OPC care team"
           }
         }
       ]
     },
     {
       "resourceType": "ActivityDefinition",
-      "id": "Week1Day2Msg",
-      "name": "Week 1 Day 2 Message",
+      "id": "Day77Msg0",
+      "name": "Day 77 Message 0",
       "status": "active",
       "kind": "CommunicationRequest",
       "timingTiming": {
         "repeat": {
           "frequency": 1,
-          "period": 9,
+          "period": 78,
           "periodUnit": "d",
           "timeOfDay": [
-            "12:30:00"
+            "08:42:00"
           ]
         }
       },
@@ -216,24 +300,23 @@
           "path": "payload.contentString",
           "expression": {
             "language": "text/cql",
-            "expression": "Hello again, {name}! Know that I am thinking of you and sending positive vibes your way! Feel free to text if you need anything. {userName}"
+            "expression": "Hey {name}. Sometimes it’s helpful to make a list of things you are thankful for. For example, we are thankful you are participating in this study! Hope you’ll find something to be thankful for today as well. -OPC care team"
           }
         }
       ]
-    },
     {
       "resourceType": "ActivityDefinition",
-      "id": "Week1Day4Msg",
-      "name": "Week 1 Day 4 Message",
+      "id": "AutumnMsg",
+      "name": "Autumn Message",
       "status": "active",
       "kind": "CommunicationRequest",
       "timingTiming": {
         "repeat": {
           "frequency": 1,
-          "period": 11,
+          "period": 60,
           "periodUnit": "d",
           "timeOfDay": [
-            "10:00:00"
+            "08:37:00"
           ]
         }
       },
@@ -242,7 +325,7 @@
           "path": "payload.contentString",
           "expression": {
             "language": "text/cql",
-            "expression": "{name}, Hope everything is going well.  {userName}"
+            "expression": "{name}, welcome to a season of change! Though change can be scary, it can be very beautiful. What positive changes have you seen this season? -OPC care team"
           }
         }
       ]
@@ -256,7 +339,7 @@
       "timingTiming": {
         "repeat": {
           "timeOfDay": [
-            "10:08:00"
+            "08:37:00"
           ]
         }
       },
@@ -265,7 +348,7 @@
           "path": "payload.contentString",
           "expression": {
             "language": "text/cql",
-            "expression": "Happy Birthday, {name}! Hope the day brings you happiness and next year holds good things for you."
+            "expression": "Happy Birthday {name}! -OPC care team"
           }
         }
       ]

--- a/src/fhir/PlanDefinition_vso.json
+++ b/src/fhir/PlanDefinition_vso.json
@@ -14,22 +14,37 @@
       "definitionCanonical": "#Day14Msg0"
     },
     {
-      "definitionCanonical": "#Day21Msg0"
+      "definitionCanonical": "#Day22Msg0"
     },
     {
-      "definitionCanonical": "#Day35Msg0"
+      "definitionCanonical": "#Day32Msg0"
     },
     {
-      "definitionCanonical": "#Day49Msg0"
+      "definitionCanonical": "#Day44Msg0"
     },
     {
-      "definitionCanonical": "#Day63Msg0"
+      "definitionCanonical": "#Day52Msg0"
     },
     {
-      "definitionCanonical": "#Day77Msg0"
+      "definitionCanonical": "#Day59Msg0"
     },
     {
-      "definitionCanonical": "#AutumnMsg"
+      "definitionCanonical": "#Day66Msg0"
+    },
+    {
+      "definitionCanonical": "#Day74Msg0"
+    },
+    {
+      "definitionCanonical": "#Day81Msg0"
+    },
+    {
+      "definitionCanonical": "#Day90Msg0"
+    },
+    {
+      "definitionCanonical": "#VeteransDayMsg"
+    },
+    {
+      "definitionCanonical": "#FallWinterMsg"
     },
     {
       "definitionCanonical": "#BirthdayMsg",
@@ -93,6 +108,7 @@
           }
         }
       ]
+    },
     {
       "resourceType": "ActivityDefinition",
       "id": "Day14Msg0",
@@ -105,7 +121,7 @@
           "period": 15,
           "periodUnit": "d",
           "timeOfDay": [
-            "08:47:00"
+            "14:36:00"
           ]
         }
       },
@@ -114,74 +130,24 @@
           "path": "payload.contentString",
           "expression": {
             "language": "text/cql",
-            "expression": "Sending good thoughts and energy your way! -OPC care team"
-          }
-        }
-      ]
-    {
-      "resourceType": "ActivityDefinition",
-      "id": "Day21Msg0",
-      "name": "Day 21 Message 0",
-      "status": "active",
-      "kind": "CommunicationRequest",
-      "timingTiming": {
-        "repeat": {
-          "frequency": 1,
-          "period": 22,
-          "periodUnit": "d",
-          "timeOfDay": [
-            "08:35:00"
-          ]
-        }
-      },
-      "dynamicValue": [
-        {
-          "path": "payload.contentString",
-          "expression": {
-            "language": "text/cql",
-            "expression": "Life can be difficult at times. We are cheering for you {name}! -OPC care team"
-          }
-        }
-      ]
-    {
-      "resourceType": "ActivityDefinition",
-      "id": "Day35Msg0",
-      "name": "Day 35 Message 0",
-      "status": "active",
-      "kind": "CommunicationRequest",
-      "timingTiming": {
-        "repeat": {
-          "frequency": 1,
-          "period": 36,
-          "periodUnit": "d",
-          "timeOfDay": [
-            "09:02:00"
-          ]
-        }
-      },
-      "dynamicValue": [
-        {
-          "path": "payload.contentString",
-          "expression": {
-            "language": "text/cql",
-            "expression": "Did you know that exercise can be helpful for treating depression? If you’re feeling low, even 10 minutes of walking can release those feel-good endorphins. -OPC care team"
+            "expression": "We will be with you all the way. -QRF NineLine Team"
           }
         }
       ]
     },
     {
       "resourceType": "ActivityDefinition",
-      "id": "Day49Msg0",
-      "name": "Day 49 Message 0",
+      "id": "Day22Msg0",
+      "name": "Day 22 Message 0",
       "status": "active",
       "kind": "CommunicationRequest",
       "timingTiming": {
         "repeat": {
           "frequency": 1,
-          "period": 50,
+          "period": 23,
           "periodUnit": "d",
           "timeOfDay": [
-            "08:40:00"
+            "09:18:00"
           ]
         }
       },
@@ -190,24 +156,24 @@
           "path": "payload.contentString",
           "expression": {
             "language": "text/cql",
-            "expression": "It’s a beautiful day to be alive {name}! Thinking of you today! -OPC care team"
+            "expression": "{name}, just letting you know, we’re not always available but if you need to talk to someone, the National Hotline number is 988 & press 1 and the Veterans Crisis Line number is 838-255. -QRF NineLine Team"
           }
         }
       ]
     },
     {
       "resourceType": "ActivityDefinition",
-      "id": "Day63Msg0",
-      "name": "Day 63 Message 0",
+      "id": "Day32Msg0",
+      "name": "Day 32 Message 0",
       "status": "active",
       "kind": "CommunicationRequest",
       "timingTiming": {
         "repeat": {
           "frequency": 1,
-          "period": 64,
+          "period": 33,
           "periodUnit": "d",
           "timeOfDay": [
-            "08:53:00"
+            "12:10:00"
           ]
         }
       },
@@ -216,21 +182,203 @@
           "path": "payload.contentString",
           "expression": {
             "language": "text/cql",
-            "expression": "We hope this message finds you well, {name}. Sending positive vibes your way. -OPC care team"
+            "expression": "Hey {name}, we know life can be difficult at times but we are cheering for you! -QRF NineLine Team"
           }
         }
       ]
     },
     {
       "resourceType": "ActivityDefinition",
-      "id": "Day77Msg0",
-      "name": "Day 77 Message 0",
+      "id": "Day44Msg0",
+      "name": "Day 44 Message 0",
       "status": "active",
       "kind": "CommunicationRequest",
       "timingTiming": {
         "repeat": {
           "frequency": 1,
-          "period": 78,
+          "period": 45,
+          "periodUnit": "d",
+          "timeOfDay": [
+            "11:30:00"
+          ]
+        }
+      },
+      "dynamicValue": [
+        {
+          "path": "payload.contentString",
+          "expression": {
+            "language": "text/cql",
+            "expression": "Hey {name}, I hope this message finds you in good health! Sending positive vibes your way! -QRF NineLine Team"
+          }
+        }
+      ]
+    },
+    {
+      "resourceType": "ActivityDefinition",
+      "id": "Day52Msg0",
+      "name": "Day 52 Message 0",
+      "status": "active",
+      "kind": "CommunicationRequest",
+      "timingTiming": {
+        "repeat": {
+          "frequency": 1,
+          "period": 53,
+          "periodUnit": "d",
+          "timeOfDay": [
+            "09:54:00"
+          ]
+        }
+      },
+      "dynamicValue": [
+        {
+          "path": "payload.contentString",
+          "expression": {
+            "language": "text/cql",
+            "expression": "Hey {name}, thinking of you today! -QRF NineLine Team"
+          }
+        }
+      ]
+    },
+    {
+      "resourceType": "ActivityDefinition",
+      "id": "Day59Msg0",
+      "name": "Day 59 Message 0",
+      "status": "active",
+      "kind": "CommunicationRequest",
+      "timingTiming": {
+        "repeat": {
+          "frequency": 1,
+          "period": 60,
+          "periodUnit": "d",
+          "timeOfDay": [
+            "13:23:00"
+          ]
+        }
+      },
+      "dynamicValue": [
+        {
+          "path": "payload.contentString",
+          "expression": {
+            "language": "text/cql",
+            "expression": "Hey {name}, sending good thoughts and energy your way! -QRF NineLine Team"
+          }
+        }
+      ]
+    },
+    {
+      "resourceType": "ActivityDefinition",
+      "id": "Day66Msg0",
+      "name": "Day 66 Message 0",
+      "status": "active",
+      "kind": "CommunicationRequest",
+      "timingTiming": {
+        "repeat": {
+          "frequency": 1,
+          "period": 67,
+          "periodUnit": "d",
+          "timeOfDay": [
+            "15:42:00"
+          ]
+        }
+      },
+      "dynamicValue": [
+        {
+          "path": "payload.contentString",
+          "expression": {
+            "language": "text/cql",
+            "expression": "Hello {name}! I hope this finds you in a good place. I believe in you and am glad to connect when you need to. -QRF NineLine Team"
+          }
+        }
+      ]
+    },
+    {
+      "resourceType": "ActivityDefinition",
+      "id": "Day74Msg0",
+      "name": "Day 74 Message 0",
+      "status": "active",
+      "kind": "CommunicationRequest",
+      "timingTiming": {
+        "repeat": {
+          "frequency": 1,
+          "period": 75,
+          "periodUnit": "d",
+          "timeOfDay": [
+            "11:32:00"
+          ]
+        }
+      },
+      "dynamicValue": [
+        {
+          "path": "payload.contentString",
+          "expression": {
+            "language": "text/cql",
+            "expression": "Hey {name}, you don’t have to walk alone, if you ever need anything we are here! -QRF NineLine Team"
+          }
+        }
+      ]
+    },
+    {
+      "resourceType": "ActivityDefinition",
+      "id": "Day81Msg0",
+      "name": "Day 81 Message 0",
+      "status": "active",
+      "kind": "CommunicationRequest",
+      "timingTiming": {
+        "repeat": {
+          "frequency": 1,
+          "period": 82,
+          "periodUnit": "d",
+          "timeOfDay": [
+            "16:50:00"
+          ]
+        }
+      },
+      "dynamicValue": [
+        {
+          "path": "payload.contentString",
+          "expression": {
+            "language": "text/cql",
+            "expression": "{name}, know that I am thinking of you today and that I believe in you. I am with you and support you. –QRF NineLine Team"
+          }
+        }
+      ]
+    },
+    {
+      "resourceType": "ActivityDefinition",
+      "id": "Day90Msg0",
+      "name": "Day 90 Message 0",
+      "status": "active",
+      "kind": "CommunicationRequest",
+      "timingTiming": {
+        "repeat": {
+          "frequency": 1,
+          "period": 91,
+          "periodUnit": "d",
+          "timeOfDay": [
+            "10:15:00"
+          ]
+        }
+      },
+      "dynamicValue": [
+        {
+          "path": "payload.contentString",
+          "expression": {
+            "language": "text/cql",
+            "expression": "Thanks again for being willing to participate in this project. If at some point you’re in need of support, please remember the 24/7 National Crisis line is 988 & press 1 and the Veterans Crisis Line number is 838-255. NineLine is here if you need us @ 253-922-7225 –QRF NineLine Team"
+          }
+        }
+      ]
+    },
+    {
+      "resourceType": "ActivityDefinition",
+      "id": "VeteransDayMsg",
+      "name": "Veterans Day Message",
+      "status": "active",
+      "kind": "CommunicationRequest",
+      "timingTiming": {
+        "repeat": {
+          "frequency": 1,
+          "period": 93,
           "periodUnit": "d",
           "timeOfDay": [
             "08:42:00"
@@ -242,23 +390,24 @@
           "path": "payload.contentString",
           "expression": {
             "language": "text/cql",
-            "expression": "Hey {name}. Sometimes it’s helpful to make a list of things you are thankful for. For example, we are thankful you are participating in this study! Hope you’ll find something to be thankful for today as well. -OPC care team"
+            "expression": "Happy Veteran’s Day. Thank you {name} for volunteering for service. What you’ve done is greatly appreciated. We know that this time can be difficult, if you need someone please reach out @ 253-922-7225. We’re here for you if you need us. -QRF NineLine Team"
           }
         }
       ]
+    },
     {
       "resourceType": "ActivityDefinition",
-      "id": "AutumnMsg",
-      "name": "Autumn Message",
+      "id": "FallWinterMsg",
+      "name": "Fall Winter Message",
       "status": "active",
       "kind": "CommunicationRequest",
       "timingTiming": {
         "repeat": {
           "frequency": 1,
-          "period": 60,
+          "period": 124,
           "periodUnit": "d",
           "timeOfDay": [
-            "08:37:00"
+            "12:34:00"
           ]
         }
       },
@@ -267,7 +416,7 @@
           "path": "payload.contentString",
           "expression": {
             "language": "text/cql",
-            "expression": "{name}, welcome to a season of change! Though change can be scary, it can be very beautiful. What positive changes have you seen this season? -OPC care team"
+            "expression": "Hey {name}, just wanted to send you encouragement this holiday season, as the darkness can sometimes negatively impact us. I hope you will be able to take care of yourself and do things that nourish you, physically, mentally and emotionally. If you ever need someone to talk to, get a hold of us at 253-922-7225. Wishing you a warm winter. -QRF NineLine team"
           }
         }
       ]
@@ -290,7 +439,7 @@
           "path": "payload.contentString",
           "expression": {
             "language": "text/cql",
-            "expression": "Happy Birthday {name}! -OPC care team"
+            "expression": "Happy Birthday, {name}! Best wishes to you in this next year of life. –QRF NineLine Team"
           }
         }
       ]

--- a/src/fhir/PlanDefinition_vso.json
+++ b/src/fhir/PlanDefinition_vso.json
@@ -1,32 +1,35 @@
 {
   "resourceType": "PlanDefinition",
   "id": "PlanDefinition_vso",
-  "title": "aring Contacts PlanDefinition for VSO",
+  "title": "Caring Contacts PlanDefinition for VSO",
   "status": "active",
   "action": [
     {
-      "definitionCanonical": "#Week0Day0Msg"
+      "definitionCanonical": "#Day0Msg0"
     },
     {
-      "definitionCanonical": "#Week0Day1Msg"
+      "definitionCanonical": "#Day6Msg0"
     },
     {
-      "definitionCanonical": "#Week0Day2Msg"
+      "definitionCanonical": "#Day14Msg0"
     },
     {
-      "definitionCanonical": "#Week0Day3Msg"
+      "definitionCanonical": "#Day21Msg0"
     },
     {
-      "definitionCanonical": "#Week0Day5Msg"
+      "definitionCanonical": "#Day35Msg0"
     },
     {
-      "definitionCanonical": "#Week1Day0Msg"
+      "definitionCanonical": "#Day49Msg0"
     },
     {
-      "definitionCanonical": "#Week1Day2Msg"
+      "definitionCanonical": "#Day63Msg0"
     },
     {
-      "definitionCanonical": "#Week1Day4Msg"
+      "definitionCanonical": "#Day77Msg0"
+    },
+    {
+      "definitionCanonical": "#AutumnMsg"
     },
     {
       "definitionCanonical": "#BirthdayMsg",
@@ -41,8 +44,8 @@
   "contained": [
     {
       "resourceType": "ActivityDefinition",
-      "id": "Week0Day0Msg",
-      "name": "Week 0 Day 0 Message",
+      "id": "Day0Msg0",
+      "name": "Day 0 Message 0",
       "status": "active",
       "kind": "CommunicationRequest",
       "timingTiming": {
@@ -51,7 +54,7 @@
           "period": 0,
           "periodUnit": "d",
           "timeOfDay": [
-            "13:30:00"
+            "18:00:00"
           ]
         }
       },
@@ -60,119 +63,15 @@
           "path": "payload.contentString",
           "expression": {
             "language": "text/cql",
-            "expression": "{name} - Good to meet you today! Could you respond so I know you got this message? Thanks {userName}"
+            "expression": "Hello {name}, hope your day is going well. You are not alone on this journey. If you need immediate help, don't forget about the 24/7 National Hotline - 988 & press 1, or you can text the Veterans Crisis Line @ 838-255, or check our website: nine9line.org -QRF NineLine Team"
           }
         }
       ]
     },
     {
       "resourceType": "ActivityDefinition",
-      "id": "Week0Day1Msg",
-      "name": "Week 0 Day 1 Message",
-      "status": "active",
-      "kind": "CommunicationRequest",
-      "timingTiming": {
-        "repeat": {
-          "frequency": 1,
-          "period": 1,
-          "periodUnit": "d",
-          "timeOfDay": [
-            "09:41:00"
-          ]
-        }
-      },
-      "dynamicValue": [
-        {
-          "path": "payload.contentString",
-          "expression": {
-            "language": "text/cql",
-            "expression": "Hi there {name}, Hope you are having a good day.  I am here for you if you need me. {userName}"
-          }
-        }
-      ]
-    },
-    {
-      "resourceType": "ActivityDefinition",
-      "id": "Week0Day2Msg",
-      "name": "Week 0 Day 2 Message",
-      "status": "active",
-      "kind": "CommunicationRequest",
-      "timingTiming": {
-        "repeat": {
-          "frequency": 1,
-          "period": 2,
-          "periodUnit": "d",
-          "timeOfDay": [
-            "12:00:00"
-          ]
-        }
-      },
-      "dynamicValue": [
-        {
-          "path": "payload.contentString",
-          "expression": {
-            "language": "text/cql",
-            "expression": "Hi {name} - You made your first steps. Don't give up now {userName}"
-          }
-        }
-      ]
-    },
-    {
-      "resourceType": "ActivityDefinition",
-      "id": "Week0Day3Msg",
-      "name": "Week 0 Day 3 Message",
-      "status": "active",
-      "kind": "CommunicationRequest",
-      "timingTiming": {
-        "repeat": {
-          "frequency": 1,
-          "period": 3,
-          "periodUnit": "d",
-          "timeOfDay": [
-            "11:20:00"
-          ]
-        }
-      },
-      "dynamicValue": [
-        {
-          "path": "payload.contentString",
-          "expression": {
-            "language": "text/cql",
-            "expression": "Hello {name}, I know life can be difficult sometimes; I just want you to know that I'm thinking about you and sending positive thoughts your way.  Sincerely, {userName}  "
-          }
-        }
-      ]
-    },
-    {
-      "resourceType": "ActivityDefinition",
-      "id": "Week0Day5Msg",
-      "name": "Week 0 Day 5 Message",
-      "status": "active",
-      "kind": "CommunicationRequest",
-      "timingTiming": {
-        "repeat": {
-          "frequency": 1,
-          "period": 5,
-          "periodUnit": "d",
-          "timeOfDay": [
-            "19:03:00"
-          ]
-        }
-      },
-      "dynamicValue": [
-        {
-          "path": "payload.contentString",
-          "expression": {
-            "language": "text/cql",
-            "expression": "Hey {name}, hope things are going well and you're having a good week. - {userName}"
-          }
-        }
-      ]
-    },
-    {
-      "resourceType": "ActivityDefinition",
-      "id": "Week1Day0Msg",
-      "name": "Week 1 Day 0 Message",
+      "id": "Day6Msg0",
+      "name": "Day 6 Message 0",
       "status": "active",
       "kind": "CommunicationRequest",
       "timingTiming": {
@@ -181,7 +80,7 @@
           "period": 7,
           "periodUnit": "d",
           "timeOfDay": [
-            "16:24:00"
+            "10:24:00"
           ]
         }
       },
@@ -190,24 +89,99 @@
           "path": "payload.contentString",
           "expression": {
             "language": "text/cql",
-            "expression": "Hi {name}, hope all's well and you're taking good care of yourself {userName}"
+            "expression": "Hey {name}, I know some days can be hard. Just know we are thinking of you and wishing you the best! -QRF NineLine Team"
+          }
+        }
+      ]
+    {
+      "resourceType": "ActivityDefinition",
+      "id": "Day14Msg0",
+      "name": "Day 14 Message 0",
+      "status": "active",
+      "kind": "CommunicationRequest",
+      "timingTiming": {
+        "repeat": {
+          "frequency": 1,
+          "period": 15,
+          "periodUnit": "d",
+          "timeOfDay": [
+            "08:47:00"
+          ]
+        }
+      },
+      "dynamicValue": [
+        {
+          "path": "payload.contentString",
+          "expression": {
+            "language": "text/cql",
+            "expression": "Sending good thoughts and energy your way! -OPC care team"
+          }
+        }
+      ]
+    {
+      "resourceType": "ActivityDefinition",
+      "id": "Day21Msg0",
+      "name": "Day 21 Message 0",
+      "status": "active",
+      "kind": "CommunicationRequest",
+      "timingTiming": {
+        "repeat": {
+          "frequency": 1,
+          "period": 22,
+          "periodUnit": "d",
+          "timeOfDay": [
+            "08:35:00"
+          ]
+        }
+      },
+      "dynamicValue": [
+        {
+          "path": "payload.contentString",
+          "expression": {
+            "language": "text/cql",
+            "expression": "Life can be difficult at times. We are cheering for you {name}! -OPC care team"
+          }
+        }
+      ]
+    {
+      "resourceType": "ActivityDefinition",
+      "id": "Day35Msg0",
+      "name": "Day 35 Message 0",
+      "status": "active",
+      "kind": "CommunicationRequest",
+      "timingTiming": {
+        "repeat": {
+          "frequency": 1,
+          "period": 36,
+          "periodUnit": "d",
+          "timeOfDay": [
+            "09:02:00"
+          ]
+        }
+      },
+      "dynamicValue": [
+        {
+          "path": "payload.contentString",
+          "expression": {
+            "language": "text/cql",
+            "expression": "Did you know that exercise can be helpful for treating depression? If you’re feeling low, even 10 minutes of walking can release those feel-good endorphins. -OPC care team"
           }
         }
       ]
     },
     {
       "resourceType": "ActivityDefinition",
-      "id": "Week1Day2Msg",
-      "name": "Week 1 Day 2 Message",
+      "id": "Day49Msg0",
+      "name": "Day 49 Message 0",
       "status": "active",
       "kind": "CommunicationRequest",
       "timingTiming": {
         "repeat": {
           "frequency": 1,
-          "period": 9,
+          "period": 50,
           "periodUnit": "d",
           "timeOfDay": [
-            "12:30:00"
+            "08:40:00"
           ]
         }
       },
@@ -216,24 +190,24 @@
           "path": "payload.contentString",
           "expression": {
             "language": "text/cql",
-            "expression": "Hello again, {name}! Know that I am thinking of you and sending positive vibes your way! Feel free to text if you need anything. {userName}"
+            "expression": "It’s a beautiful day to be alive {name}! Thinking of you today! -OPC care team"
           }
         }
       ]
     },
     {
       "resourceType": "ActivityDefinition",
-      "id": "Week1Day4Msg",
-      "name": "Week 1 Day 4 Message",
+      "id": "Day63Msg0",
+      "name": "Day 63 Message 0",
       "status": "active",
       "kind": "CommunicationRequest",
       "timingTiming": {
         "repeat": {
           "frequency": 1,
-          "period": 11,
+          "period": 64,
           "periodUnit": "d",
           "timeOfDay": [
-            "10:00:00"
+            "08:53:00"
           ]
         }
       },
@@ -242,7 +216,58 @@
           "path": "payload.contentString",
           "expression": {
             "language": "text/cql",
-            "expression": "{name}, Hope everything is going well.  {userName}"
+            "expression": "We hope this message finds you well, {name}. Sending positive vibes your way. -OPC care team"
+          }
+        }
+      ]
+    },
+    {
+      "resourceType": "ActivityDefinition",
+      "id": "Day77Msg0",
+      "name": "Day 77 Message 0",
+      "status": "active",
+      "kind": "CommunicationRequest",
+      "timingTiming": {
+        "repeat": {
+          "frequency": 1,
+          "period": 78,
+          "periodUnit": "d",
+          "timeOfDay": [
+            "08:42:00"
+          ]
+        }
+      },
+      "dynamicValue": [
+        {
+          "path": "payload.contentString",
+          "expression": {
+            "language": "text/cql",
+            "expression": "Hey {name}. Sometimes it’s helpful to make a list of things you are thankful for. For example, we are thankful you are participating in this study! Hope you’ll find something to be thankful for today as well. -OPC care team"
+          }
+        }
+      ]
+    {
+      "resourceType": "ActivityDefinition",
+      "id": "AutumnMsg",
+      "name": "Autumn Message",
+      "status": "active",
+      "kind": "CommunicationRequest",
+      "timingTiming": {
+        "repeat": {
+          "frequency": 1,
+          "period": 60,
+          "periodUnit": "d",
+          "timeOfDay": [
+            "08:37:00"
+          ]
+        }
+      },
+      "dynamicValue": [
+        {
+          "path": "payload.contentString",
+          "expression": {
+            "language": "text/cql",
+            "expression": "{name}, welcome to a season of change! Though change can be scary, it can be very beautiful. What positive changes have you seen this season? -OPC care team"
           }
         }
       ]
@@ -256,7 +281,7 @@
       "timingTiming": {
         "repeat": {
           "timeOfDay": [
-            "10:08:00"
+            "08:37:00"
           ]
         }
       },
@@ -265,7 +290,7 @@
           "path": "payload.contentString",
           "expression": {
             "language": "text/cql",
-            "expression": "Happy Birthday, {name}! Hope the day brings you happiness and next year holds good things for you."
+            "expression": "Happy Birthday {name}! -OPC care team"
           }
         }
       ]

--- a/src/fhir/PlanDefinition_vso.json
+++ b/src/fhir/PlanDefinition_vso.json
@@ -92,7 +92,7 @@
       "timingTiming": {
         "repeat": {
           "frequency": 1,
-          "period": 7,
+          "period": 6,
           "periodUnit": "d",
           "timeOfDay": [
             "10:24:00"
@@ -118,7 +118,7 @@
       "timingTiming": {
         "repeat": {
           "frequency": 1,
-          "period": 15,
+          "period": 14,
           "periodUnit": "d",
           "timeOfDay": [
             "14:36:00"
@@ -144,7 +144,7 @@
       "timingTiming": {
         "repeat": {
           "frequency": 1,
-          "period": 23,
+          "period": 22,
           "periodUnit": "d",
           "timeOfDay": [
             "09:18:00"
@@ -170,7 +170,7 @@
       "timingTiming": {
         "repeat": {
           "frequency": 1,
-          "period": 33,
+          "period": 32,
           "periodUnit": "d",
           "timeOfDay": [
             "12:10:00"
@@ -196,7 +196,7 @@
       "timingTiming": {
         "repeat": {
           "frequency": 1,
-          "period": 45,
+          "period": 44,
           "periodUnit": "d",
           "timeOfDay": [
             "11:30:00"
@@ -222,7 +222,7 @@
       "timingTiming": {
         "repeat": {
           "frequency": 1,
-          "period": 53,
+          "period": 52,
           "periodUnit": "d",
           "timeOfDay": [
             "09:54:00"
@@ -248,7 +248,7 @@
       "timingTiming": {
         "repeat": {
           "frequency": 1,
-          "period": 60,
+          "period": 59,
           "periodUnit": "d",
           "timeOfDay": [
             "13:23:00"
@@ -274,7 +274,7 @@
       "timingTiming": {
         "repeat": {
           "frequency": 1,
-          "period": 67,
+          "period": 66,
           "periodUnit": "d",
           "timeOfDay": [
             "15:42:00"
@@ -300,7 +300,7 @@
       "timingTiming": {
         "repeat": {
           "frequency": 1,
-          "period": 75,
+          "period": 74,
           "periodUnit": "d",
           "timeOfDay": [
             "11:32:00"
@@ -326,7 +326,7 @@
       "timingTiming": {
         "repeat": {
           "frequency": 1,
-          "period": 82,
+          "period": 81,
           "periodUnit": "d",
           "timeOfDay": [
             "16:50:00"
@@ -352,7 +352,7 @@
       "timingTiming": {
         "repeat": {
           "frequency": 1,
-          "period": 91,
+          "period": 90,
           "periodUnit": "d",
           "timeOfDay": [
             "10:15:00"


### PR DESCRIPTION
... We'll need to implement the ability to handle abstract dates for a few messages (eg "AutumnMsg"), it needs to be sent on a specific date rather than 60 days in - we'll do that in a separate PR post-release (https://www.pivotaltracker.com/story/show/185634954 ). For now, these are hard-coded to be some time out from enrollment datetime (like other non-birthday messages), and staff will just edit their dates as need be.