### PR TITLE
Support discrete datetimes for messages in PlanDefinition

### DIFF
--- a/src/fhir/PlanDefinition_opc.json
+++ b/src/fhir/PlanDefinition_opc.json
@@ -257,11 +257,9 @@
       "status": "active",
       "kind": "CommunicationRequest",
       "timingTiming": {
-        "schedule": {
-          "event": [
-            "2023-09-25T15:33:00.000Z"
-          ]
-        }
+        "event": [
+          "2023-09-25T15:33:00.000Z"
+        ]
       },
       "dynamicValue": [
         {

--- a/src/fhir/PlanDefinition_opc.json
+++ b/src/fhir/PlanDefinition_opc.json
@@ -257,12 +257,9 @@
       "status": "active",
       "kind": "CommunicationRequest",
       "timingTiming": {
-        "repeat": {
-          "frequency": 1,
-          "period": 60,
-          "periodUnit": "d",
-          "timeOfDay": [
-            "08:37:00"
+        "schedule": {
+          "event": [
+            "2023-09-25T15:33:00.000Z"
           ]
         }
       },

--- a/src/fhir/PlanDefinition_vso.json
+++ b/src/fhir/PlanDefinition_vso.json
@@ -376,12 +376,9 @@
       "status": "active",
       "kind": "CommunicationRequest",
       "timingTiming": {
-        "repeat": {
-          "frequency": 1,
-          "period": 93,
-          "periodUnit": "d",
-          "timeOfDay": [
-            "08:42:00"
+        "schedule": {
+          "event": [
+            "2023-11-11T16:42:00.000Z"
           ]
         }
       },
@@ -402,12 +399,9 @@
       "status": "active",
       "kind": "CommunicationRequest",
       "timingTiming": {
-        "repeat": {
-          "frequency": 1,
-          "period": 124,
-          "periodUnit": "d",
-          "timeOfDay": [
-            "12:34:00"
+        "schedule": {
+          "event": [
+            "2023-11-22T20:34:00.000Z"
           ]
         }
       },

--- a/src/fhir/PlanDefinition_vso.json
+++ b/src/fhir/PlanDefinition_vso.json
@@ -376,11 +376,9 @@
       "status": "active",
       "kind": "CommunicationRequest",
       "timingTiming": {
-        "schedule": {
-          "event": [
-            "2023-11-11T16:42:00.000Z"
-          ]
-        }
+        "event": [
+          "2023-11-11T16:42:00.000Z"
+        ]
       },
       "dynamicValue": [
         {
@@ -399,11 +397,9 @@
       "status": "active",
       "kind": "CommunicationRequest",
       "timingTiming": {
-        "schedule": {
-          "event": [
-            "2023-11-22T20:34:00.000Z"
-          ]
-        }
+        "event": [
+          "2023-11-22T20:34:00.000Z"
+        ]
       },
       "dynamicValue": [
         {

--- a/src/model/PlanDefinition.ts
+++ b/src/model/PlanDefinition.ts
@@ -132,21 +132,27 @@ export class ActivityDefinition implements IActivityDefinition {
     }
 
     occurrenceTimeFromNow(): Date {
-        if (!this.timingTiming?.repeat) {
-            throw Error("No timing or repeat specified in ActivityDefinition")
+        if (!(this.timingTiming.event || this.timingTiming?.repeat)) {
+            throw Error("No event, timing or repeat specified in ActivityDefinition")
         }
-        if (this.timingTiming.repeat.periodUnit && this.timingTiming.repeat.periodUnit !== 'wk' && this.timingTiming.repeat.periodUnit !== 'd') {
-            throw Error("Unhandled time unit in timingTiming");
+        if (
+          this.timingTiming.repeat?.periodUnit &&
+          this.timingTiming.repeat?.periodUnit !== "wk" &&
+          this.timingTiming.repeat?.periodUnit !== "d"
+        ) {
+          throw Error("Unhandled time unit in timingTiming");
         }
 
         let date = new Date();
-        if (this.timingTiming.repeat.periodUnit === 'wk') {
+        if (this.timingTiming.event && Array.isArray(this.timingTiming.event)) {
+            date = new Date(this.timingTiming.event[0]);
+        } else if (this.timingTiming.repeat.periodUnit === 'wk') {
             date.setDate(date.getDate() + 7 * this.timingTiming.repeat.period);
         } else if (this.timingTiming.repeat.periodUnit === 'd') {
             date.setDate(date.getDate() + this.timingTiming.repeat.period);
         }
 
-        if (!this.timingTiming.repeat.timeOfDay) {
+        if (!this.timingTiming.repeat?.timeOfDay) {
             return date;
         }
 


### PR DESCRIPTION
Support discrete datetimes for messages in PlanDefinition

For https://www.pivotaltracker.com/story/show/185634954 

Per https://www.hl7.org/fhir/datatypes-examples.html#Timing