### PR TITLE
add missing Observation import

### DIFF
--- a/src/components/ScheduleSetup.tsx
+++ b/src/components/ScheduleSetup.tsx
@@ -39,6 +39,7 @@ import Dialog from "@mui/material/Dialog";
 import Client from "fhirclient/lib/Client";
 import PatientNotes from "./PatientNotes";
 import CarePlan from "../model/CarePlan";
+import { Observation } from "../model/Observation";
 import {Bundle} from "../model/Bundle";
 import { getFhirData } from "../util/isacc_util";
 import { unmarkTestPatient} from "../model/modelUtil";


### PR DESCRIPTION
For some reason, the import for Observation dropped...adding it back.
It was causing `Observation not defined` error when observations are being saved.