### PR TITLE
remove code that substitutes template variables in messages

### DIFF
--- a/src/components/EnrollmentApp.tsx
+++ b/src/components/EnrollmentApp.tsx
@@ -35,19 +35,10 @@ export default class EnrollmentApp extends React.Component<{}, EnrollmenAppState
         //@ts-ignore
         let patient: Patient = this.context.patient;
         //@ts-ignore
-        //let client: Client = this.context.client;
-
-        //@ts-ignore
         let ctxPlanDefinition = this.context.planDefinition;
 
         let replacements: { [key: string]: string } = {};
-        // let name = getUserName(client);
-        // if (name) {
-        //     replacements['{userName}'] = name;
-        // } else {
-        //     replacements['{userName}'] = "Caring Contacts Team";
-        // }
-
+    
         const messages: CommunicationRequest[] = ctxPlanDefinition.createMessageList(patient, replacements);
         const carePlan = makeCarePlan(ctxPlanDefinition, patient, messages);
 

--- a/src/components/EnrollmentApp.tsx
+++ b/src/components/EnrollmentApp.tsx
@@ -9,7 +9,7 @@ import {Alert, AlertTitle, Button, CircularProgress, Stack, Typography} from "@m
 import CarePlan from "../model/CarePlan";
 import {IsaccMessageCategory} from "../model/CodeSystem";
 import {IBundle_Entry, ICommunicationRequest} from "@ahryman40k/ts-fhir-types/lib/R4";
-import {getFhirData, getUserName} from "../util/isacc_util";
+import {getFhirData} from "../util/isacc_util";
 import Patient from "../model/Patient";
 import {Bundle} from "../model/Bundle";
 
@@ -35,18 +35,18 @@ export default class EnrollmentApp extends React.Component<{}, EnrollmenAppState
         //@ts-ignore
         let patient: Patient = this.context.patient;
         //@ts-ignore
-        let client: Client = this.context.client;
+        //let client: Client = this.context.client;
 
         //@ts-ignore
         let ctxPlanDefinition = this.context.planDefinition;
 
         let replacements: { [key: string]: string } = {};
-        let name = getUserName(client);
-        if (name) {
-            replacements['{userName}'] = name;
-        } else {
-            replacements['{userName}'] = "Caring Contacts Team";
-        }
+        // let name = getUserName(client);
+        // if (name) {
+        //     replacements['{userName}'] = name;
+        // } else {
+        //     replacements['{userName}'] = "Caring Contacts Team";
+        // }
 
         const messages: CommunicationRequest[] = ctxPlanDefinition.createMessageList(patient, replacements);
         const carePlan = makeCarePlan(ctxPlanDefinition, patient, messages);

--- a/src/components/ScheduleSetup.tsx
+++ b/src/components/ScheduleSetup.tsx
@@ -775,8 +775,13 @@ const MessageScheduleList = (props: {
             />
           </Stack>
         </Stack>
-        <Alert severity={"info"}>
-          {"Use {name} to substitute the recipient's first name"}
+        <Alert
+          severity={"info"}
+        >
+          <div dangerouslySetInnerHTML={{
+            __html:
+              "{name} will be substituted by the recipient's first name or preferred name if available.<br/>{userName} will be substituted by the author's first name.",
+          }}></div>
         </Alert>
 
         <List>
@@ -797,7 +802,7 @@ const MessageScheduleList = (props: {
             variant="outlined"
             size="large"
             sx={{
-              minWidth: (theme) => theme.spacing(33)
+              minWidth: (theme) => theme.spacing(33),
             }}
             onClick={() => {
               let newMessage = CommunicationRequest.createNewScheduledMessage(

--- a/src/model/modelUtil.ts
+++ b/src/model/modelUtil.ts
@@ -13,9 +13,6 @@ export function makeCommunicationRequests(
   messages: MessageDraft[]
 ): CommunicationRequest[] {
   return messages.map((message) => {
-    //let patientName = patient.name[0].given[0];
-    //let str = message.text.replace("{name}", patientName);
-
     return CommunicationRequest.createNewScheduledMessage(
       message.text,
       patient,

--- a/src/model/modelUtil.ts
+++ b/src/model/modelUtil.ts
@@ -13,11 +13,11 @@ export function makeCommunicationRequests(
   messages: MessageDraft[]
 ): CommunicationRequest[] {
   return messages.map((message) => {
-    let patientName = patient.name[0].given[0];
-    let str = message.text.replace("{name}", patientName);
+    //let patientName = patient.name[0].given[0];
+    //let str = message.text.replace("{name}", patientName);
 
     return CommunicationRequest.createNewScheduledMessage(
-      str,
+      message.text,
       patient,
       null,
       message.scheduledDateTime


### PR DESCRIPTION
frontend changes for this story: https://www.pivotaltracker.com/n/projects/2584667/stories/185514809

Remove code that substitues `{name}` for recipeint's first name, i.e. `patient.name[0].given[0]` (or preferred name if available, i.e., `patient.name[where use = 'usual'].given[0]`) and `userName` for the author's first name (referenced in the `generalPractitioner` of the FHIR Patient resource)

Screenshot after the code changes:
![MessageView](https://github.com/uwcirg/isacc-messaging-client-sof/assets/12942714/ba505850-9822-4c3d-8380-20759527df44)
