### PR TITLE
Remove document body size display at page corner

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,8 @@ export default class App extends React.Component<any, any> {
                                 <EnrollmentApp/> :
                                 <MessagingApp/>
                         }
-                        <SizeIndicator/>
+                        {/* indicator document body size, uncomment for debugging */}
+                        {/* <SizeIndicator/> */}
                     </FhirClientProvider>
                 </LocalizationProvider>
             </ThemeProvider>


### PR DESCRIPTION
see [related convo](https://cirg.slack.com/archives/C03HTRD8RRS/p1694538046229309?thread_ts=1694446095.166719&cid=C03HTRD8RRS) in Slack

This will remove the text displayed at bottom corner (see screenshot) that displays the size of body document:
![sizeIndicator](https://github.com/uwcirg/isacc-messaging-client-sof/assets/12942714/f6c41475-d5be-4782-8ea0-330951c01664)


I think it might have been meant for debugging?  Commented out the code for now, can be uncommented for debugging purpose.