### PR TITLE
PlanDefinition - do not display message with hard-coded date from past

### DIFF
--- a/src/model/PlanDefinition.ts
+++ b/src/model/PlanDefinition.ts
@@ -61,6 +61,8 @@ export default class PlanDefinition implements IPlanDefinition {
                         }
                     }
                     let date = activityDef.occurrenceTimeFromNow();
+                    // check if hard-coded date is in the past
+                    if (activityDef?.timingTiming?.event && (new Date(date)).getTime() < (new Date()).getTime()) return null;
                     return {
                         text: contentString,
                         scheduledDateTime: date


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186171864
his change will prevent message with hard-coded date, e.g. containing Timingtiming.event element, from being listed on the UI

example screenshot after fix (fall message not included):
![Screen Shot 2023-10-03 at 10 05 02 AM](https://github.com/uwcirg/isacc-messaging-client-sof/assets/12942714/b5d64e61-3b9e-48c8-adb3-ec1bc4e57b21)
