### PR TITLE
Enrollment app: handle past schedule messages

### DIFF
--- a/src/components/ScheduleSetup.tsx
+++ b/src/components/ScheduleSetup.tsx
@@ -645,6 +645,7 @@ export default class ScheduleSetup extends React.Component<
       }
       let promises = this.state.carePlan.communicationRequests
         .filter((c: CommunicationRequest) => {
+          // do not create CR for message that does not have a active status or date/time is in the past
           if (c.status !== "active") return false;
           if (dateInPast(c.occurrenceDateTime)) return false;
           // for a current active CommunicationRequest
@@ -895,6 +896,7 @@ const MessageScheduleList = (props: {
                     }}
                   />
                 </LocalizationProvider>
+                {/* display warning if the message date/time is in the past */}
                 {isInPast && (
                   <Alert
                     severity="warning"

--- a/src/components/ScheduleSetup.tsx
+++ b/src/components/ScheduleSetup.tsx
@@ -645,9 +645,18 @@ export default class ScheduleSetup extends React.Component<
       }
       let promises = this.state.carePlan.communicationRequests
         .filter((c: CommunicationRequest) => {
-          // do not create CR for message that does not have a active status or date/time is in the past
+          // do not create CR for message that does not have a active status
           if (c.status !== "active") return false;
-          if (dateInPast(c.occurrenceDateTime)) return false;
+          // date time in the past
+          if (dateInPast(c.occurrenceDateTime)) {
+              if (c.id) {
+                // CR already exists, update its status to "revoked" so it won't be sent
+                c.status = "revoked";
+              } else {
+                // if a new message, don't create CR for it
+                return false;
+              }
+          }
           // for a current active CommunicationRequest
           // check for matching CommunicationRequest that has been completed, i.e. sent (status === 'completed')
           const matchedCompletedCr = completedCRs.find(

--- a/src/components/ScheduleSetup.tsx
+++ b/src/components/ScheduleSetup.tsx
@@ -834,7 +834,8 @@ const MessageScheduleList = (props: {
 
     const buildMessageItem = (message: CommunicationRequest, index: number) => {
         const isInPast = dateInPast(message.occurrenceDateTime);
-        const shouldDisable = message.status === "completed";
+        const messageCompleted = message.status === "completed";
+        const shouldShowPastWarning = !messageCompleted && isInPast;
         return (
           <ListItem
             key={`message_${index}`}
@@ -877,7 +878,7 @@ const MessageScheduleList = (props: {
                     // @ts-ignore
                     value={moment(message.occurrenceDateTime)}
                     format="ddd, MM/DD/YYYY hh:mm A" // example output display: Thu, 03/09/2023 09:34 AM
-                    disabled={shouldDisable}
+                    disabled={messageCompleted}
                     onChange={(newValue: Date | null) => {
                       message.setOccurrenceDate(newValue);
                       props.onMessagePlanChanged(props.messagePlan);
@@ -906,7 +907,7 @@ const MessageScheduleList = (props: {
                   />
                 </LocalizationProvider>
                 {/* display warning if the message date/time is in the past */}
-                {isInPast && (
+                {shouldShowPastWarning && (
                   <Alert
                     severity="warning"
                     variant="outlined"
@@ -939,7 +940,7 @@ const MessageScheduleList = (props: {
                   multiline
                   value={message.getText() ?? ""}
                   placeholder={"Enter message"}
-                  disabled={shouldDisable}
+                  disabled={messageCompleted}
                   onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
                     message.setText(event.target.value);
                     props.onMessagePlanChanged(props.messagePlan);

--- a/src/components/ScheduleSetup.tsx
+++ b/src/components/ScheduleSetup.tsx
@@ -914,7 +914,7 @@ const MessageScheduleList = (props: {
                     sx={{
                       border: 0,
                       wordWrap: "break-word",
-                      maxWidth: 200,
+                      maxWidth: 240,
                       padding: 0,
                       alignItems: "center",
                     }}
@@ -1019,11 +1019,12 @@ const MessageScheduleList = (props: {
               minWidth: (theme) => theme.spacing(33),
             }}
             onClick={() => {
+              const today = new Date((new Date()).getTime() + 5 * 60000);
               let newMessage = CommunicationRequest.createNewScheduledMessage(
                 "",
                 props.patient,
                 props.messagePlan,
-                new Date()
+                today
               );
               props.messagePlan.addCommunicationRequest(newMessage);
               props.onMessagePlanChanged(props.messagePlan);

--- a/src/components/ScheduleSetup.tsx
+++ b/src/components/ScheduleSetup.tsx
@@ -1019,7 +1019,7 @@ const MessageScheduleList = (props: {
               minWidth: (theme) => theme.spacing(33),
             }}
             onClick={() => {
-              const today = new Date((new Date()).getTime() + 5 * 60000);
+              const today = new Date((new Date()).getTime() + 60 * 1 * 60000);
               let newMessage = CommunicationRequest.createNewScheduledMessage(
                 "",
                 props.patient,

--- a/src/fhir/PlanDefinition.json
+++ b/src/fhir/PlanDefinition.json
@@ -54,7 +54,7 @@
           "period": 0,
           "periodUnit": "d",
           "timeOfDay": [
-            "13:30:00"
+            "09:30:00"
           ]
         }
       },

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -63,6 +63,11 @@ export function getEnvs() {
     };
 }
 
+/*
+ * check is passed dateString is in the past
+ * @param dateString in string
+ * @return boolean
+ */
 export function dateInPast (dateString) {
     const dateToCompare = new Date(dateString);
     dateToCompare.setSeconds(0);
@@ -70,6 +75,6 @@ export function dateInPast (dateString) {
     const today = new Date();
     today.setSeconds(0);
     today.setMilliseconds(0);
-    return  dateToCompare < today;
+    return dateToCompare < today;
 }
 export const queryPatientIdKey = 'launch_queryPatientId';

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -63,4 +63,13 @@ export function getEnvs() {
     };
 }
 
+export function dateInPast (dateString) {
+    const dateToCompare = new Date(dateString);
+    dateToCompare.setSeconds(0);
+    dateToCompare.setMilliseconds(0);
+    const today = new Date();
+    today.setSeconds(0);
+    today.setMilliseconds(0);
+    return  dateToCompare < today;
+}
 export const queryPatientIdKey = 'launch_queryPatientId';


### PR DESCRIPTION
see [Slack convo](https://cirg.slack.com/archives/C03HTRD8RRS/p1699377411079109?thread_ts=1699050825.112629&cid=C03HTRD8RRS)
part of https://www.pivotaltracker.com/story/show/183693507

Changes include:
- add check to see if a scheduled message is in the past, if so:
 no CommunicationRequest resource will be created for it if it is a newly scheduled message
if a CommunicationRequest has already been created, its status will be updated to `revoked`
- add warning on UI to user if a scheduled message is in the past:
![Screen Shot 2023-11-07 at 11 52 44 AM](https://github.com/uwcirg/isacc-messaging-client-sof/assets/12942714/294e6dc5-f8ab-4424-a8d4-b8e35a80aea3)
