### PR TITLE
Messaging client: handle last unfollowed message date/time when outside communication is sent

### DIFF
--- a/src/model/CodeSystem.ts
+++ b/src/model/CodeSystem.ts
@@ -110,6 +110,7 @@ export const ExtensionUrl = {
     studyStatusUrl: "isacc.app/study-status",
     pronounsUrl: "http://hl7.org/fhir/StructureDefinition/individual-genderIdentity",
     nextScheduledgMessageDateTimeUrl: "http://isacc.app/date-time-of-next-outgoing-message",
+    lastUnfollowedMessageDateTimeUrl: "http://isacc.app/time-of-last-unfollowedup-message"
 }
 
 export const SystemURL = {

--- a/src/model/Patient.ts
+++ b/src/model/Patient.ts
@@ -66,6 +66,7 @@ export default class Patient implements IPatient {
   }
   
   static TEST_PATIENT_SECURITY_CODE = "HTEST";
+  static UNSET_LAST_UNFOLLOWED_DATETIME = "2025-01-01T00:00:00Z";
 
   get smsContactPoint(): string {
     let p = this.telecom?.filter(
@@ -391,6 +392,32 @@ export default class Patient implements IPatient {
     if (!existingDateTime) {
       existingDateTime = {
         url: ExtensionUrl.nextScheduledgMessageDateTimeUrl,
+      };
+      this.extension.push(existingDateTime);
+    }
+    existingDateTime.valueDateTime = value;
+  }
+
+  get lastUnfollowedMessageDateTime(): string {
+    let o = this.extension?.filter(
+      (i: IExtension) => i.url === ExtensionUrl.lastUnfollowedMessageDateTimeUrl
+    )[0];
+    return o ? o.valueDateTime : null;
+  }
+
+  set lastUnfollowedMessageDateTime(value: string) {
+    if (!value) {
+      return;
+    }
+    if (!this.extension) {
+      this.extension = [];
+    }
+    let existingDateTime = this.extension?.filter(
+      (i: IExtension) => i.url === ExtensionUrl.lastUnfollowedMessageDateTimeUrl
+    )[0];
+    if (!existingDateTime) {
+      existingDateTime = {
+        url: ExtensionUrl.lastUnfollowedMessageDateTimeUrl,
       };
       this.extension.push(existingDateTime);
     }


### PR DESCRIPTION
part of https://www.pivotaltracker.com/story/show/185895123
change includes:
If an outside communication is sent via the Messaging client app and the date/time of this outside communication **does not** pre-date the datetime of existing `time-of-last-unfollowed-message` extension, the recipient's `time-of-last-unfollowedup-message` extension datetime will be updated to `2025-01-01T00:00:00Z` (implying that there is no unfollowed message; the date/time is a future date/time so that `Time since reply` column can be displayed/sorted correctly.)