### PR TITLE
Enrollment client - remove next message date/time extension when there is no active communicationRequest

### DIFF
--- a/src/components/ScheduleSetup.tsx
+++ b/src/components/ScheduleSetup.tsx
@@ -588,6 +588,7 @@ export default class ScheduleSetup extends React.Component<
       },
       (reason: any) => {
         this.showSnackbar("error", reason);
+        setTimeout(() => window.scrollTo(0, 0), 0);
       }
     );
   }

--- a/src/components/ScheduleSetup.tsx
+++ b/src/components/ScheduleSetup.tsx
@@ -721,30 +721,39 @@ export default class ScheduleSetup extends React.Component<
                       console.log("CommunicationRequest updated:", v);
                     }
                   );
-                  const activeScheduledCommunicationRequests = updatedCommunicationRequests
-                    .filter(
-                      (ucr : CommunicationRequest) =>
-                        ucr.status === "active" &&
-                        CommunicationRequest.isScheduledOutgoingMessage(ucr)
-                    )
-                    .sort((a, b) => {
-                      let d1 = a.occurrenceDateTime;
-                      let d2 = b.occurrenceDateTime;
-                      const t1 = d1 ? new Date(d1).getTime() : 0;
-                      const t2 = d2 ? new Date(d2).getTime() : 0;
-                      return t1 - t2;
-                    });
+                  const activeScheduledCommunicationRequests =
+                    updatedCommunicationRequests
+                      .filter(
+                        (ucr: CommunicationRequest) =>
+                          ucr.status === "active" &&
+                          CommunicationRequest.isScheduledOutgoingMessage(ucr)
+                      )
+                      .sort((a, b) => {
+                        let d1 = a.occurrenceDateTime;
+                        let d2 = b.occurrenceDateTime;
+                        const t1 = d1 ? new Date(d1).getTime() : 0;
+                        const t2 = d2 ? new Date(d2).getTime() : 0;
+                        return t1 - t2;
+                      });
 
                   // console.log("next ", activeCommunicationRequests[0].occurrenceDateTime)
                   // add next scheduled message date/time extension
                   patient.nextScheduledMessageDateTime =
-                  activeScheduledCommunicationRequests.length
-                      ? activeScheduledCommunicationRequests[0]?.occurrenceDateTime
-                      : null;
-                  if (patient.nextScheduledMessageDateTime) {
+                    activeScheduledCommunicationRequests.length
+                      ? activeScheduledCommunicationRequests[0]
+                          ?.occurrenceDateTime
+                      : null; // set next scheduled message date/time to null if there is no active communicationRequest
+                  client
                     // @ts-ignore
-                    client.update(patient).then(() => this.onSaved(savedCarePlan));
-                  } else this.onSaved(savedCarePlan);
+                    .update(patient)
+                    .then(() => this.onSaved(savedCarePlan))
+                    .catch((e) => {
+                      this.showSnackbar(
+                        "warning",
+                        `Issue encountered updating patient's next scheduled message date/time. See console for detail.`
+                      );
+                      this.onSaved(savedCarePlan)
+                    });
                 }
               );
             },

--- a/src/model/Patient.ts
+++ b/src/model/Patient.ts
@@ -381,6 +381,12 @@ export default class Patient implements IPatient {
 
   set nextScheduledMessageDateTime(value: string) {
     if (!value) {
+      if (this.extension) {
+        // if next scheduled message date time is null then removed the extension
+        this.extension = this.extension?.filter(
+          (i: IExtension) => i.url !== ExtensionUrl.nextScheduledgMessageDateTimeUrl
+        );
+      }
       return;
     }
     if (!this.extension) {


### PR DESCRIPTION
per [Slack convo](https://cirg.slack.com/archives/C03HTRD8RRS/p1699982247701299?thread_ts=1699922753.684519&cid=C03HTRD8RRS)
Fix is to address when there is no active CommunicationRequest for a recipient (e.g. as when all the scheduled messages are removed).
In that case, the extension for `next-scheduled-message-date-time` is removed from Patient FHIR resource when `Done` is clicked and data saved.