### PR TITLE
Patient telecom field: add period

### DIFF
--- a/src/model/Patient.ts
+++ b/src/model/Patient.ts
@@ -16,6 +16,7 @@ import {
   IPatient_Communication,
   IPatient_Contact,
   IPatient_Link,
+  IPeriod,
   IReference,
   IResourceList,
   PatientGenderKind
@@ -86,7 +87,13 @@ export default class Patient implements IPatient {
     )[0];
 
     if (!smsContactPoint) {
-      smsContactPoint = { system: ContactPointSystemKind._sms };
+      const smsPeriod: IPeriod = {
+        start: new Date().toISOString(),
+      };
+      smsContactPoint = {
+        system: ContactPointSystemKind._sms,
+        period: smsPeriod,
+      };
       this.telecom.push(smsContactPoint);
     }
 

--- a/src/model/Patient.ts
+++ b/src/model/Patient.ts
@@ -87,16 +87,15 @@ export default class Patient implements IPatient {
     )[0];
 
     if (!smsContactPoint) {
-      const smsPeriod: IPeriod = {
-        start: new Date().toISOString(),
-      };
       smsContactPoint = {
-        system: ContactPointSystemKind._sms,
-        period: smsPeriod,
+        system: ContactPointSystemKind._sms
       };
       this.telecom.push(smsContactPoint);
     }
-
+    const smsPeriod: IPeriod = {
+      start: new Date().toISOString(),
+    };
+    smsContactPoint.period = smsPeriod;
     smsContactPoint.value = phone;
   }
 


### PR DESCRIPTION
to support: https://www.pivotaltracker.com/story/show/186225639
add `period` element to the `telecom` field for a Patient resource

example when saved:
```
 "telecom": [
    {
      "system": "sms",
      "value": "7637722731",
      "period": {
        "start": "2024-01-31T23:32:44.229Z"
      }
    }
  ]
```

