### PR TITLE
messaging client: fix overflowing long message in bubble

### DIFF
--- a/src/components/MessagingView.tsx
+++ b/src/components/MessagingView.tsx
@@ -1548,7 +1548,15 @@ export default class MessagingView extends React.Component<
     let messageGroup = (
       <Grid item xs={11} md={10} lg={8}>
         <Stack direction={"column"} alignItems={align} paddingBottom={0.5}>
-          <Stack direction={"row"} alignItems={"center"} spacing={1}>
+          <Stack
+            direction={"row"}
+            alignItems={"center"}
+            spacing={1}
+            sx={{
+              whiteSpace: "normal",
+              wordBreak: "break-word",
+            }}
+          >
             {bubbleAndPriorityRow}
           </Stack>
           {themes.length > 0 && (
@@ -1576,7 +1584,7 @@ export default class MessagingView extends React.Component<
                 sx={{
                   whiteSpace: "pre", // preserve line break character
                   textAlign: incoming ? "left" : "right",
-                  color: error ? red[900] : "#0009"
+                  color: error ? red[900] : "#0009",
                 }}
               >
                 {comment}


### PR DESCRIPTION
per feedback from test. See Slack convo [here](https://cirg.slack.com/archives/C03HTRD8RRS/p1708723719794019).

Fix formatting for long message in bubble.

Before fix:
![BeforeFix](https://github.com/uwcirg/isacc-messaging-client-sof/assets/12942714/172ed9c7-9393-483b-8c98-bb0dbe8d7891)

After fix:
![AfterFix](https://github.com/uwcirg/isacc-messaging-client-sof/assets/12942714/d64cc535-9e2e-4adf-861c-5f78471ded6b)
