### PR TITLE
Bugfix/careplan date

### DIFF
--- a/src/components/EnrollmentApp.tsx
+++ b/src/components/EnrollmentApp.tsx
@@ -36,6 +36,7 @@ type EnrollmenAppState = {
     carePlanStartDate: Date | null;
     selectedCarePlanStartDate: Date | null;
     startDateModalOpen: boolean;
+    loaded: boolean;
 }
 
 export default class EnrollmentApp extends React.Component<{}, EnrollmenAppState> {
@@ -50,6 +51,7 @@ export default class EnrollmentApp extends React.Component<{}, EnrollmenAppState
       carePlanStartDate: null,
       selectedCarePlanStartDate: null,
       startDateModalOpen: true,
+      loaded: false
     };
   }
 
@@ -174,6 +176,15 @@ export default class EnrollmentApp extends React.Component<{}, EnrollmenAppState
         : existingCarePlan.created;
       this.setState({
         carePlanStartDate: new Date(startDate),
+      }, () => {
+        // make sure care plan date is set before presenting the view
+        this.setState({
+          loaded: true
+        });
+      });
+    } else {
+      this.setState({
+        loaded: true
       });
     }
   }
@@ -364,9 +375,10 @@ export default class EnrollmentApp extends React.Component<{}, EnrollmenAppState
     );
   }
   render(): React.ReactNode {
-    if (!this.state || !this.context) return <CircularProgress />;
+    if (!this.state || !this.context || !this.state.loaded) return <CircularProgress />;
 
     let view = <CircularProgress />;
+    
     if (!this.state.carePlanStartDate) {
       view = this.getCarePlanStartDateModalView();
     } else if (this.state.activeCarePlan != null) {

--- a/src/components/EnrollmentApp.tsx
+++ b/src/components/EnrollmentApp.tsx
@@ -270,6 +270,7 @@ export default class EnrollmentApp extends React.Component<{}, EnrollmenAppState
         onClose={handleClose}
         aria-labelledby="careplan-date-dialog-title"
         aria-describedby="careplan-date-dialog-description"
+        sx={{zIndex: 10}}
       >
         <DialogTitle id="careplan-date-dialog-title">
           {"Please specify the CarePlan start date"}

--- a/src/components/EnrollmentApp.tsx
+++ b/src/components/EnrollmentApp.tsx
@@ -21,7 +21,7 @@ import {
 import { AdapterMoment } from "@mui/x-date-pickers/AdapterMoment";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import moment from "moment";
-import {DateTimePicker} from "@mui/x-date-pickers/DateTimePicker";
+import {DatePicker} from "@mui/x-date-pickers/DatePicker";
 import CarePlan from "../model/CarePlan";
 import {IsaccMessageCategory} from "../model/CodeSystem";
 import {IBundle_Entry, ICommunicationRequest} from "@ahryman40k/ts-fhir-types/lib/R4";
@@ -269,11 +269,11 @@ export default class EnrollmentApp extends React.Component<{}, EnrollmenAppState
             sx={{ padding: (theme) => theme.spacing(1, 0, 0) }}
           >
             <LocalizationProvider dateAdapter={AdapterMoment}>
-              <DateTimePicker
-                label="Start date & time"
+              <DatePicker
+                label="Start date"
                 // @ts-ignore
-                value={selectedValue ?? moment()}
-                format="ddd, MM/DD/YYYY hh:mm A" // example output display: Thu, 03/09/2023 09:34 AM
+                value={selectedValue}
+                format="ddd, MM/DD/YYYY" // example output display: Thu, 03/09/2023
                 onChange={(newValue: moment.Moment | null) => {
                   this.setState({
                     selectedCarePlanStartDate: newValue.toDate(),


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/187751321
Followup fix - addressed issue where dialog for prompting CarePlan start date is errantly displayed for user that already has a careplan.

Fix includes 

add check for rendering view only after careplan date (if any) has been set.  This will ensure that the dialog will only display if it is determined that no careplan date(or a careplan) has been set before.