### PR TITLE
Enrollment - ensure next scheduled date/time is not in the past

### DIFF
--- a/src/components/ScheduleSetup.tsx
+++ b/src/components/ScheduleSetup.tsx
@@ -737,7 +737,8 @@ export default class ScheduleSetup extends React.Component<
                       .filter(
                         (ucr: CommunicationRequest) =>
                           ucr.status === "active" &&
-                          CommunicationRequest.isScheduledOutgoingMessage(ucr)
+                          CommunicationRequest.isScheduledOutgoingMessage(ucr) &&
+                          !dateInPast(ucr.occurrenceDateTime)
                       )
                       .sort((a, b) => {
                         let d1 = a.occurrenceDateTime;


### PR DESCRIPTION
Address feedback from https://www.pivotaltracker.com/story/show/187751321
When saving next scheduled date/time, make sure it is not in the past before doing so.