### PR TITLE
remove debug statement on key press

### DIFF
--- a/src/components/MessagingView.tsx
+++ b/src/components/MessagingView.tsx
@@ -363,7 +363,6 @@ export default class MessagingView extends React.Component<
       let communications = [];
       communications.push(...this.state.communications);
       communications.push(...this.state.temporaryCommunications);
-      console.log("communications to be sorted ", communications);
       communications.sort((a, b) => {
         let d1 = a.sent ? a.sent : a.received ?? a.meta?.lastUpdated;
         let d2 = b.sent ? b.sent : b.received ?? b.meta?.lastUpdated;


### PR DESCRIPTION
Address issue raised in convo Slack:
https://cirg.slack.com/archives/C03HTRD8RRS/p1720037933879869

remove code to print debug statement on keypress that might cause lag when entering text

the code was introduced [here](https://github.com/uwcirg/isacc-messaging-client-sof/commit/b86bcf15551095fd97e253379295db4056554ebd#diff-ecc3420995ac53a698706c9b76aea2e203c950f91b7526d190907e893e27ae0dR443)