### PR TITLE
create communication for marked as resolved

### DIFF
--- a/src/components/MessagingView.tsx
+++ b/src/components/MessagingView.tsx
@@ -588,7 +588,7 @@ export default class MessagingView extends React.Component<
           >
             <Box>
               <Typography variant="subtitle2" component="div">
-                Last time since reply:{" "}
+                Time since last reply:{" "}
                 {getTimeAgoDisplay(
                   new Date(patient.lastUnfollowedMessageDateTime)
                 )}

--- a/src/components/MessagingView.tsx
+++ b/src/components/MessagingView.tsx
@@ -545,7 +545,7 @@ export default class MessagingView extends React.Component<
       activeMessage: {
         ...this.state.activeMessage,
         date: new Date().toISOString(),
-        content: "Marked as read",
+        content: "Prior message(s) marked as read",
         status: "sent",
         type: "marked as read"
       },
@@ -579,7 +579,7 @@ export default class MessagingView extends React.Component<
             },
           }}
         >
-          <AlertTitle>Un-responded message</AlertTitle>
+          <AlertTitle>Un-responded message(s)</AlertTitle>
           <Stack
             spacing={1}
             direction={"column"}
@@ -588,7 +588,7 @@ export default class MessagingView extends React.Component<
           >
             <Box>
               <Typography variant="subtitle2" component="div">
-                Time since reply:{" "}
+                Last time since reply:{" "}
                 {getTimeAgoDisplay(
                   new Date(patient.lastUnfollowedMessageDateTime)
                 )}
@@ -606,7 +606,7 @@ export default class MessagingView extends React.Component<
               onClick={() => this.handleMarkedAsResolve()}
               variant="outlined"
             >
-              Mark message as read/resolved
+              Mark message(s) as read/resolved
             </Button>
           </Stack>
         </Alert>

--- a/src/model/CodeSystem.ts
+++ b/src/model/CodeSystem.ts
@@ -76,6 +76,10 @@ export const IsaccMessageCategory = {
   isaccComment: Coding.make(
     "https://isacc.app/CodeSystem/communication-type",
     "isacc-comment"
+  ),
+  isaccMarkedAsResolved: Coding.make(
+    "https://isacc.app/CodeSystem/communication-type",
+    "isacc-message-resolved-no-send"
   )
 };
 


### PR DESCRIPTION
part of story https://www.pivotaltracker.com/story/show/188624366

- create a new communication when a messaged is marked as read.
Example communication posted:
```
{
        "resourceType": "Communication",
        "id": "2604598",
        "meta": {
          "versionId": "1",
          "lastUpdated": "2024-11-27T18:28:56.642-05:00"
        },
        "partOf": [
          {
            "reference": "CarePlan/2596233"
          }
        ],
        "status": "completed",
        "category": [
          {
            "coding": [
              {
                "system": "https://isacc.app/CodeSystem/communication-type",
                "code": "isacc-message-resolved-no-send"
              }
            ]
          }
        ],
        "subject": {
          "reference": "Patient/2cda5aad-e409-4070-9a15-e1c35c46ed5a"
        },
        "sent": "2024-11-27T23:28:56.345Z",
        "payload": [
          {
            "contentString": "Prior message(s) marked as read"
          }
        ],
        "note": [
          {
            "text": "marked as read, staff-entered"
          }
        ]
      }
```

Will be displayed on the UI in the messages panel as such:
prior to resolving/marking as read:
![Screenshot 2024-12-02 at 11 20 08 AM](https://github.com/user-attachments/assets/de5b058f-faf4-4df0-a039-a05c6833ecf5)
after marking as read:
![Screenshot 2024-12-02 at 11 20 57 AM](https://github.com/user-attachments/assets/d796b616-3d19-47cb-89b6-cadf167cdbdd)

