### PR TITLE
handle active tab after marking as read

### DIFF
--- a/src/components/MessagingView.tsx
+++ b/src/components/MessagingView.tsx
@@ -1297,7 +1297,9 @@ export default class MessagingView extends React.Component<
       this.setState({
         activeMessage: {
           ...defaultMessage,
-          type: messageType,
+          // this will allow the ISACC manual tab to be selected after marking a message as resolved
+          // otherwise no tab will be selected, which is confusing on the UI
+          type: isMarkedAsResolved ? "sms" : messageType,
         },
         error: null,
       });


### PR DESCRIPTION
per [Slack convo](https://cirg.slack.com/archives/C03HTRD8RRS/p1733358543046869)

After fix,
screenshot after marking message as read:

![Screenshot 2024-12-04 at 4 59 45 PM](https://github.com/user-attachments/assets/25deb71a-7def-426e-9a28-06402cc0ee24)
